### PR TITLE
Sets the max number of concurrent downloads to 10.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,7 @@ platform :ios, '7.0'
 pod 'AFNetworking',	'~> 2.3.1'
 pod 'CocoaLumberjack', '~> 1.8.1'
 pod 'DTCoreText',   '1.6.13'
+pod 'Reachability', '~> 3.1.1'
 
 target 'WordPress-iOS-SharedTests', :exclusive => true do
     pod 'OHHTTPStubs', '3.1.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,14 +30,15 @@ PODS:
     - DTFoundation/DTAnimatedGIF (~> 1.7.1)
     - DTFoundation/DTHTMLParser (~> 1.7.1)
     - DTFoundation/UIKit (~> 1.7.1)
-  - DTFoundation/Core (1.7.1)
-  - DTFoundation/DTAnimatedGIF (1.7.1)
-  - DTFoundation/DTHTMLParser (1.7.1):
+  - DTFoundation/Core (1.7.2)
+  - DTFoundation/DTAnimatedGIF (1.7.2)
+  - DTFoundation/DTHTMLParser (1.7.2):
     - DTFoundation/Core
-  - DTFoundation/UIKit (1.7.1):
+  - DTFoundation/UIKit (1.7.2):
     - DTFoundation/Core
   - OCMock (3.0.1)
   - OHHTTPStubs (3.1.1)
+  - Reachability (3.1.1)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.3.1)
@@ -45,13 +46,15 @@ DEPENDENCIES:
   - DTCoreText (= 1.6.13)
   - OCMock
   - OHHTTPStubs (= 3.1.1)
+  - Reachability (~> 3.1.1)
 
 SPEC CHECKSUMS:
   AFNetworking: 6d7b76aa5d04c8c37daad3eef4b7e3f2a7620da3
   CocoaLumberjack: 9d198d6e19909b3b113a38c5f06f7bb8eedd0427
   DTCoreText: 84eb8ba2e70448fdd9d837540e371f9f587b65ba
-  DTFoundation: ef6fb95da64f202d1600bc23dde79c6fd74c0c2d
+  DTFoundation: 126729614911ae7dbab3dcc1c078f189943bee66
   OCMock: bd152939402e75c7eb4b912d54ba27be33e57fc7
   OHHTTPStubs: 58b42d245ad2416bac170ce18e1383913d17e315
+  Reachability: 8e9635e3cb4f98e7f825e51147f677ecc694d0e7
 
 COCOAPODS: 0.33.1

--- a/WordPress-iOS-Shared.xcodeproj/project.pbxproj
+++ b/WordPress-iOS-Shared.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		931A1038192AA34300D3CC11 /* WPImageSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1037192AA34300D3CC11 /* WPImageSourceTest.m */; };
 		931A103B192AA35B00D3CC11 /* AsyncTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A103A192AA35B00D3CC11 /* AsyncTestHelper.m */; };
 		931A103E192AA3DB00D3CC11 /* test-image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 931A103D192AA3DB00D3CC11 /* test-image.jpg */; };
+		A288C3D1199A655A00E789FD /* CTNetworkHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = A288C3D0199A655A00E789FD /* CTNetworkHelper.m */; };
 		F45AF04D6E344F4CBD2A4B65 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB8B405468864FD7A0D16B74 /* libPods.a */; };
 /* End PBXBuildFile section */
 
@@ -101,6 +102,8 @@
 		931A1039192AA35B00D3CC11 /* AsyncTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AsyncTestHelper.h; sourceTree = "<group>"; };
 		931A103A192AA35B00D3CC11 /* AsyncTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AsyncTestHelper.m; sourceTree = "<group>"; };
 		931A103D192AA3DB00D3CC11 /* test-image.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "test-image.jpg"; sourceTree = "<group>"; };
+		A288C3CF199A655A00E789FD /* CTNetworkHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTNetworkHelper.h; sourceTree = "<group>"; };
+		A288C3D0199A655A00E789FD /* CTNetworkHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTNetworkHelper.m; sourceTree = "<group>"; };
 		A7CDA9068CC847B2AD67DE41 /* libPods-WordPress-iOS-SharedTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WordPress-iOS-SharedTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB8B405468864FD7A0D16B74 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F41764475ADE4A768BB073D2 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
@@ -167,6 +170,7 @@
 		931A0FEF192A9CDD00D3CC11 /* WordPress-iOS-Shared */ = {
 			isa = PBXGroup;
 			children = (
+				A288C3CE199A651700E789FD /* Helpers */,
 				931A101D192A9DC500D3CC11 /* Views */,
 				931A1013192A9CEA00D3CC11 /* Utilility */,
 				931A0FF0192A9CDD00D3CC11 /* Supporting Files */,
@@ -261,6 +265,15 @@
 				931A103D192AA3DB00D3CC11 /* test-image.jpg */,
 			);
 			name = "Test Data";
+			sourceTree = "<group>";
+		};
+		A288C3CE199A651700E789FD /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				A288C3CF199A655A00E789FD /* CTNetworkHelper.h */,
+				A288C3D0199A655A00E789FD /* CTNetworkHelper.m */,
+			);
+			name = Helpers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -425,6 +438,7 @@
 				9309B533192F9C2000B69F69 /* WPAnimatedImageResponseSerializer.m in Sources */,
 				931A1035192AA03600D3CC11 /* UIColor+Helpers.m in Sources */,
 				931A1019192A9D6E00D3CC11 /* NSString+XMLExtensions.m in Sources */,
+				A288C3D1199A655A00E789FD /* CTNetworkHelper.m in Sources */,
 				931A101C192A9DA500D3CC11 /* WPImageSource.m in Sources */,
 				931A1029192A9E2400D3CC11 /* WPTableViewCell.m in Sources */,
 			);

--- a/WordPress-iOS-Shared/CTNetworkHelper.h
+++ b/WordPress-iOS-Shared/CTNetworkHelper.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@interface CTNetworkHelper : NSObject
+
+@property (nonatomic, readwrite) NSInteger maxConcurrentDownloads;
+
++ (id)sharedNetworkHelper;
+
+@end

--- a/WordPress-iOS-Shared/CTNetworkHelper.m
+++ b/WordPress-iOS-Shared/CTNetworkHelper.m
@@ -2,6 +2,12 @@
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <Reachability.h>
 
+@interface CTNetworkHelper () {
+    CTTelephonyNetworkInfo *_telephonyInfo;
+}
+
+@end
+
 @implementation CTNetworkHelper
 
 + (id)sharedNetworkHelper
@@ -11,20 +17,27 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         sharedHelper = [[self alloc] init];
+    });
 
-        CTTelephonyNetworkInfo *telephonyInfo = [CTTelephonyNetworkInfo new];
-        [sharedHelper updateMaxConcurrentDownloadsForCurrentConnection:telephonyInfo];
+    return sharedHelper;
+}
+
+- (id)init
+{
+    if (self = [super init]) {
+        _telephonyInfo = [CTTelephonyNetworkInfo new];
+        [self updateMaxConcurrentDownloadsForCurrentConnection:_telephonyInfo];
 
         [NSNotificationCenter.defaultCenter addObserverForName:CTRadioAccessTechnologyDidChangeNotification
                                                         object:nil
                                                          queue:nil
                                                     usingBlock:^(NSNotification *note)
          {
-             [[CTNetworkHelper sharedNetworkHelper] updateMaxConcurrentDownloadsForCurrentConnection:telephonyInfo];
+             [self updateMaxConcurrentDownloadsForCurrentConnection:_telephonyInfo];
          }];
-    });
+    }
 
-    return sharedHelper;
+    return self;
 }
 
 #pragma mark - Private Methods

--- a/WordPress-iOS-Shared/CTNetworkHelper.m
+++ b/WordPress-iOS-Shared/CTNetworkHelper.m
@@ -1,0 +1,77 @@
+#import "CTNetworkHelper.h"
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#import <Reachability.h>
+
+@implementation CTNetworkHelper
+
++ (id)sharedNetworkHelper
+{
+    static CTNetworkHelper *sharedHelper = nil;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedHelper = [[self alloc] init];
+
+        CTTelephonyNetworkInfo *telephonyInfo = [CTTelephonyNetworkInfo new];
+        [sharedHelper updateMaxConcurrentDownloadsForCurrentConnection:telephonyInfo];
+
+        [NSNotificationCenter.defaultCenter addObserverForName:CTRadioAccessTechnologyDidChangeNotification
+                                                        object:nil
+                                                         queue:nil
+                                                    usingBlock:^(NSNotification *note)
+         {
+             [[CTNetworkHelper sharedNetworkHelper] updateMaxConcurrentDownloadsForCurrentConnection:telephonyInfo];
+         }];
+    });
+
+    return sharedHelper;
+}
+
+#pragma mark - Private Methods
+
+- (void)updateMaxConcurrentDownloadsForCurrentConnection:(CTTelephonyNetworkInfo *)telephonyInfo
+{
+    Reachability *reachability = [Reachability reachabilityForInternetConnection];
+    [reachability startNotifier];
+    NetworkStatus networkStatus = [reachability currentReachabilityStatus];
+
+    // if all else fails, set maxConcurrentDownloads to 5
+    self.maxConcurrentDownloads = 5;
+
+    if (networkStatus == NotReachable) {
+            self.maxConcurrentDownloads = 0;
+    } else if (networkStatus == ReachableViaWiFi) {
+            self.maxConcurrentDownloads = 10;
+    } else if (networkStatus == ReachableViaWWAN) {
+            // Comparison of wireless data standards:
+            // http://en.wikipedia.org/wiki/Comparison_of_wireless_data_standards#Peak_bit_rate_and_throughput
+
+            NSString *currentRadioAccessTechnology = telephonyInfo.currentRadioAccessTechnology;
+            if ([currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyGPRS] ||
+                [currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyCDMA1x] ||
+                [currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyWCDMA] ||
+                [currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyEdge])
+            {
+                // <1Mb/s
+                self.maxConcurrentDownloads = 3;
+            } else if ([currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyCDMAEVDORev0] ||
+                       [currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyCDMAEVDORevA] ||
+                       [currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyCDMAEVDORevB])
+            {
+                // 1Mb/s to 5Mb/s
+                self.maxConcurrentDownloads = 5;
+            } else if ([currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyHSDPA] ||
+                       [currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyHSUPA])
+            {
+                // 5Mb/s to 15Mb/s
+                self.maxConcurrentDownloads = 7;
+            } else {
+                // >15Mb/s or no cell radio connection
+                self.maxConcurrentDownloads = 10;
+            }
+    } else {
+        NSAssert(true, @"should never get here");
+    }
+}
+
+@end

--- a/WordPress-iOS-Shared/WPImageSource.m
+++ b/WordPress-iOS-Shared/WPImageSource.m
@@ -2,6 +2,7 @@
 #import "WPImageSource.h"
 
 #import "WPAnimatedImageResponseSerializer.h"
+#import "CTNetworkHelper.h"
 
 static int ddLogLevel = LOG_LEVEL_INFO;
 NSUInteger const WPImageSourceMaxConcurrentOperations = 10;
@@ -34,7 +35,10 @@ NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
     self = [super init];
     if (self) {
         _downloadingQueue = [[NSOperationQueue alloc] init];
-        [_downloadingQueue setMaxConcurrentOperationCount:WPImageSourceMaxConcurrentOperations];
+
+        CTNetworkHelper *networkHelper = [CTNetworkHelper sharedNetworkHelper];
+        [_downloadingQueue setMaxConcurrentOperationCount:networkHelper.maxConcurrentDownloads];
+
         _urlDownloadsInProgress = [[NSMutableSet alloc] init];
         _successBlocks = [[NSMutableDictionary alloc] init];
         _failureBlocks = [[NSMutableDictionary alloc] init];

--- a/WordPress-iOS-Shared/WPImageSource.m
+++ b/WordPress-iOS-Shared/WPImageSource.m
@@ -5,7 +5,6 @@
 #import "CTNetworkHelper.h"
 
 static int ddLogLevel = LOG_LEVEL_INFO;
-NSUInteger const WPImageSourceMaxConcurrentOperations = 10;
 NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
 
 @implementation WPImageSource {

--- a/WordPress-iOS-Shared/WPImageSource.m
+++ b/WordPress-iOS-Shared/WPImageSource.m
@@ -50,7 +50,11 @@ NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
     [self downloadImageForURL:url authToken:nil withSuccess:success failure:failure];
 }
 
-- (void)downloadImageForURL:(NSURL *)url authToken:(NSString *)authToken withSuccess:(void (^)(UIImage *))success failure:(void (^)(NSError *))failure {
+- (void)downloadImageForURL:(NSURL *)url
+                  authToken:(NSString *)authToken
+                withSuccess:(void (^)(UIImage *))success
+                    failure:(void (^)(NSError *))failure
+{
     NSParameterAssert(url != nil);
     
     [self addCallbackForURL:url withSuccess:success failure:failure];
@@ -63,17 +67,22 @@ NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
 
 #pragma mark - Downloader
 
-- (void)startDownloadForURL:(NSURL *)url authToken:(NSString *)authToken {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+- (void)startDownloadForURL:(NSURL *)url authToken:(NSString *)authToken
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
+    {
         NSURL *requestURL = url;
         if (authToken) {
             if (![url.absoluteString hasPrefix:@"https"]) {
-                NSString *sslUrl = [url.absoluteString stringByReplacingOccurrencesOfString:@"http://" withString:@"https://"];
+                NSString *sslUrl = [url.absoluteString stringByReplacingOccurrencesOfString:@"http://"
+                                                                                 withString:@"https://"];
                 requestURL = [NSURL URLWithString:sslUrl];
             }
         }
         
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL cachePolicy:NSURLRequestReturnCacheDataElseLoad timeoutInterval:60];
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL
+                                                               cachePolicy:NSURLRequestReturnCacheDataElseLoad
+                                                           timeoutInterval:60];
         if (authToken) {
             [request addValue:[NSString stringWithFormat:@"Bearer %@", authToken] forHTTPHeaderField:@"Authorization"];
         }
@@ -126,7 +135,8 @@ NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
 
 - (void)downloadSucceededWithNilImageForURL:(NSURL *)url response:(NSHTTPURLResponse *)response
 {
-    DDLogError(@"WPImageSource download completed sucessfully but the image was nil. Headers: %@", [response allHeaderFields]);
+    DDLogError(@"WPImageSource download completed sucessfully but the image was nil. Headers: %@",
+               [response allHeaderFields]);
     NSString *description = [NSString stringWithFormat:@"A download request ended successfully but the image was nil. URL: %@", [url absoluteString]];
     NSError *error = [NSError errorWithDomain:WPImageSourceErrorDomain
                                          code:WPImageSourceErrorNilImage

--- a/WordPress-iOS-Shared/WPImageSource.m
+++ b/WordPress-iOS-Shared/WPImageSource.m
@@ -4,7 +4,7 @@
 #import "WPAnimatedImageResponseSerializer.h"
 
 static int ddLogLevel = LOG_LEVEL_INFO;
-
+NSUInteger const WPImageSourceMaxConcurrentOperations = 10;
 NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
 
 @implementation WPImageSource {
@@ -34,6 +34,7 @@ NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
     self = [super init];
     if (self) {
         _downloadingQueue = [[NSOperationQueue alloc] init];
+        [_downloadingQueue setMaxConcurrentOperationCount:WPImageSourceMaxConcurrentOperations];
         _urlDownloadsInProgress = [[NSMutableSet alloc] init];
         _successBlocks = [[NSMutableDictionary alloc] init];
         _failureBlocks = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Ten might be a little too generous, four or five might be better, but its a starting point that we can tune over time. 
The idea is that we want to prevent apparent network slowness due to the number of concurrent downloads at any given time.