### PR TITLE
Use proper import statement syntax for frameworks

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '7.0'
-pod 'AFNetworking',	'~> 2.5.1'
+pod 'AFNetworking',	'~> 2.5'
 pod 'CocoaLumberjack', '~> 1.9'
 
 target 'WordPress-iOS-SharedTests', :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - AFNetworking (2.5.1):
-    - AFNetworking/NSURLConnection (= 2.5.1)
-    - AFNetworking/NSURLSession (= 2.5.1)
-    - AFNetworking/Reachability (= 2.5.1)
-    - AFNetworking/Security (= 2.5.1)
-    - AFNetworking/Serialization (= 2.5.1)
-    - AFNetworking/UIKit (= 2.5.1)
-  - AFNetworking/NSURLConnection (2.5.1):
+  - AFNetworking (2.5.3):
+    - AFNetworking/NSURLConnection (= 2.5.3)
+    - AFNetworking/NSURLSession (= 2.5.3)
+    - AFNetworking/Reachability (= 2.5.3)
+    - AFNetworking/Security (= 2.5.3)
+    - AFNetworking/Serialization (= 2.5.3)
+    - AFNetworking/UIKit (= 2.5.3)
+  - AFNetworking/NSURLConnection (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.1):
+  - AFNetworking/NSURLSession (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.1)
-  - AFNetworking/Security (2.5.1)
-  - AFNetworking/Serialization (2.5.1)
-  - AFNetworking/UIKit (2.5.1):
+  - AFNetworking/Reachability (2.5.3)
+  - AFNetworking/Security (2.5.3)
+  - AFNetworking/Serialization (2.5.3)
+  - AFNetworking/UIKit (2.5.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - CocoaLumberjack (1.9.2):
@@ -25,19 +25,19 @@ PODS:
   - CocoaLumberjack/Core (1.9.2)
   - CocoaLumberjack/Extensions (1.9.2):
     - CocoaLumberjack/Core
-  - OCMock (3.1.1)
+  - OCMock (3.1.2)
   - OHHTTPStubs (3.1.1)
 
 DEPENDENCIES:
-  - AFNetworking (~> 2.5.1)
+  - AFNetworking (~> 2.5)
   - CocoaLumberjack (~> 1.9)
   - OCMock
   - OHHTTPStubs (= 3.1.1)
 
 SPEC CHECKSUMS:
-  AFNetworking: 8bee59492a6ff15d69130efa4d0dc67e0094a52a
-  CocoaLumberjack: 205769c032b5fef85b92472046bcc8b7e7c8a817
-  OCMock: f6cb8c162ab9d5620dddf411282c7b2c0ee78854
-  OHHTTPStubs: 58b42d245ad2416bac170ce18e1383913d17e315
+  AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
+  CocoaLumberjack: 628fca2e88ef06f7cf6817309aa405f325d9a6fa
+  OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
+  OHHTTPStubs: cc1b9cb45b963daf891aa736f35d29d74308f0c9
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.36.4

--- a/WordPress-iOS-Shared.xcodeproj/project.pbxproj
+++ b/WordPress-iOS-Shared.xcodeproj/project.pbxproj
@@ -208,7 +208,7 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		931A1013192A9CEA00D3CC11 /* Utilility */ = {
+		931A1013192A9CEA00D3CC11 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
 				744DA844194F3A76002CD6E9 /* UIImage+Util.h */,
@@ -226,7 +226,7 @@
 				74F535F61961F7E6002D4320 /* WPFontManager.h */,
 				74F535F71961F7E6002D4320 /* WPFontManager.m */,
 			);
-			name = Utilility;
+			name = Utility;
 			path = ..;
 			sourceTree = "<group>";
 		};
@@ -274,7 +274,7 @@
 			isa = PBXGroup;
 			children = (
 				931A101D192A9DC500D3CC11 /* Views */,
-				931A1013192A9CEA00D3CC11 /* Utilility */,
+				931A1013192A9CEA00D3CC11 /* Utility */,
 			);
 			path = Core;
 			sourceTree = "<group>";

--- a/WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.h
+++ b/WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.h
@@ -1,4 +1,4 @@
-#import "AFURLResponseSerialization.h"
+#import <AFNetworking/AFURLResponseSerialization.h>
 
 /**
  *	@brief		A custom response serializer to handle GIF animations.

--- a/WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.m
+++ b/WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.m
@@ -1,6 +1,5 @@
 #import "WPAnimatedImageResponseSerializer.h"
 
-
 @implementation WPAnimatedImageResponseSerializer
 
 #pragma mark - AFImageResponseSerializer


### PR DESCRIPTION
Fixes #62 

Updates an import statement for an AFNetworking framework header so that other pods using this one will pass validation.