### PR TITLE
Update to CocoaLumberjack 2.0 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '7.0'
 pod 'AFNetworking',	'~> 2.5'
-pod 'CocoaLumberjack', '~> 1.9'
+pod 'CocoaLumberjack', '~> 2.0'
 
 target 'WordPress-iOS-SharedTests', :exclusive => true do
     pod 'OHHTTPStubs', '3.1.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,23 +20,26 @@ PODS:
   - AFNetworking/UIKit (2.5.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - CocoaLumberjack (1.9.2):
-    - CocoaLumberjack/Extensions (= 1.9.2)
-  - CocoaLumberjack/Core (1.9.2)
-  - CocoaLumberjack/Extensions (1.9.2):
+  - CocoaLumberjack (2.0.0):
+    - CocoaLumberjack/Default (= 2.0.0)
+    - CocoaLumberjack/Extensions (= 2.0.0)
+  - CocoaLumberjack/Core (2.0.0)
+  - CocoaLumberjack/Default (2.0.0):
     - CocoaLumberjack/Core
+  - CocoaLumberjack/Extensions (2.0.0):
+    - CocoaLumberjack/Default
   - OCMock (3.1.2)
   - OHHTTPStubs (3.1.1)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.5)
-  - CocoaLumberjack (~> 1.9)
+  - CocoaLumberjack (~> 2.0)
   - OCMock
   - OHHTTPStubs (= 3.1.1)
 
 SPEC CHECKSUMS:
   AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
-  CocoaLumberjack: 628fca2e88ef06f7cf6817309aa405f325d9a6fa
+  CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
   OHHTTPStubs: cc1b9cb45b963daf891aa736f35d29d74308f0c9
 

--- a/WordPress-iOS-Shared-Example/Podfile.lock
+++ b/WordPress-iOS-Shared-Example/Podfile.lock
@@ -1,33 +1,36 @@
 PODS:
-  - AFNetworking (2.5.1):
-    - AFNetworking/NSURLConnection (= 2.5.1)
-    - AFNetworking/NSURLSession (= 2.5.1)
-    - AFNetworking/Reachability (= 2.5.1)
-    - AFNetworking/Security (= 2.5.1)
-    - AFNetworking/Serialization (= 2.5.1)
-    - AFNetworking/UIKit (= 2.5.1)
-  - AFNetworking/NSURLConnection (2.5.1):
+  - AFNetworking (2.5.3):
+    - AFNetworking/NSURLConnection (= 2.5.3)
+    - AFNetworking/NSURLSession (= 2.5.3)
+    - AFNetworking/Reachability (= 2.5.3)
+    - AFNetworking/Security (= 2.5.3)
+    - AFNetworking/Serialization (= 2.5.3)
+    - AFNetworking/UIKit (= 2.5.3)
+  - AFNetworking/NSURLConnection (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.1):
+  - AFNetworking/NSURLSession (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.1)
-  - AFNetworking/Security (2.5.1)
-  - AFNetworking/Serialization (2.5.1)
-  - AFNetworking/UIKit (2.5.1):
+  - AFNetworking/Reachability (2.5.3)
+  - AFNetworking/Security (2.5.3)
+  - AFNetworking/Serialization (2.5.3)
+  - AFNetworking/UIKit (2.5.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - CocoaLumberjack (1.9.2):
-    - CocoaLumberjack/Extensions (= 1.9.2)
-  - CocoaLumberjack/Core (1.9.2)
-  - CocoaLumberjack/Extensions (1.9.2):
+  - CocoaLumberjack (2.0.0):
+    - CocoaLumberjack/Default (= 2.0.0)
+    - CocoaLumberjack/Extensions (= 2.0.0)
+  - CocoaLumberjack/Core (2.0.0)
+  - CocoaLumberjack/Default (2.0.0):
     - CocoaLumberjack/Core
-  - WordPress-iOS-Shared (0.2.2):
-    - AFNetworking (~> 2.5.1)
-    - CocoaLumberjack (~> 1.9)
+  - CocoaLumberjack/Extensions (2.0.0):
+    - CocoaLumberjack/Default
+  - WordPress-iOS-Shared (0.3.2):
+    - AFNetworking (~> 2.5)
+    - CocoaLumberjack (~> 2.0)
 
 DEPENDENCIES:
   - WordPress-iOS-Shared (from `../`)
@@ -37,8 +40,8 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: 8bee59492a6ff15d69130efa4d0dc67e0094a52a
-  CocoaLumberjack: 205769c032b5fef85b92472046bcc8b7e7c8a817
-  WordPress-iOS-Shared: d3c541c243b16508e83909c92c8c5ed29df31e05
+  AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
+  CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
+  WordPress-iOS-Shared: bd0506db9b824611246f35e774832ecbc18fc45e
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.36.4

--- a/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example/ColorsTableViewController.m
+++ b/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example/ColorsTableViewController.m
@@ -93,8 +93,8 @@
              @{@"title": @"Table View Action Color", @"color": [WPStyleGuide tableViewActionColor]},
              @{@"title": @"Button Action Color", @"color": [WPStyleGuide buttonActionColor]},
              @{@"title": @"Keyboard Color", @"color": [WPStyleGuide keyboardColor]},
-             @{@"title": @"Notifications Light Grey", @"color": [WPStyleGuide notificationsLightGrey]},
-             @{@"title": @"Notifications Dark Grey", @"color": [WPStyleGuide notificationsDarkGrey]},
+//             @{@"title": @"Notifications Light Grey", @"color": [WPStyleGuide notificationsLightGrey]},
+//             @{@"title": @"Notifications Dark Grey", @"color": [WPStyleGuide notificationsDarkGrey]},
              @{@"title": @"NUX Form Text", @"color": [WPStyleGuide nuxFormText]},
              @{@"title": @"NUX Form Placeholder Text", @"color": [WPStyleGuide nuxFormPlaceholderText]}
              ];

--- a/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example/ColorsTableViewController.m
+++ b/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example/ColorsTableViewController.m
@@ -93,8 +93,6 @@
              @{@"title": @"Table View Action Color", @"color": [WPStyleGuide tableViewActionColor]},
              @{@"title": @"Button Action Color", @"color": [WPStyleGuide buttonActionColor]},
              @{@"title": @"Keyboard Color", @"color": [WPStyleGuide keyboardColor]},
-//             @{@"title": @"Notifications Light Grey", @"color": [WPStyleGuide notificationsLightGrey]},
-//             @{@"title": @"Notifications Dark Grey", @"color": [WPStyleGuide notificationsDarkGrey]},
              @{@"title": @"NUX Form Text", @"color": [WPStyleGuide nuxFormText]},
              @{@"title": @"NUX Form Placeholder Text", @"color": [WPStyleGuide nuxFormPlaceholderText]}
              ];

--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.3.1"
+  s.version      = "0.3.2"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.prefix_header_file = "WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch"
   s.requires_arc = true
 
-  s.dependency 'AFNetworking',	'~> 2.5.1'
-  s.dependency 'CocoaLumberjack', '~> 1.9'
+  s.dependency 'AFNetworking',	'~> 2.5'
+  s.dependency 'CocoaLumberjack', '~> 2.0'
 end

--- a/WordPress-iOS-Shared/Core/WPFontManager.m
+++ b/WordPress-iOS-Shared/Core/WPFontManager.m
@@ -1,8 +1,6 @@
 #import "WPFontManager.h"
 #import <CoreText/CoreText.h>
 
-static int ddLogLevel = LOG_LEVEL_INFO;
-
 @implementation WPFontManager
 
 static NSString * const kBundle = @"WordPress-iOS-Shared.bundle";

--- a/WordPress-iOS-Shared/Core/WPImageSource.m
+++ b/WordPress-iOS-Shared/Core/WPImageSource.m
@@ -3,8 +3,6 @@
 
 #import "WPAnimatedImageResponseSerializer.h"
 
-static int ddLogLevel = LOG_LEVEL_INFO;
-
 NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
 
 @implementation WPImageSource {

--- a/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
+++ b/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
@@ -6,7 +6,7 @@
 
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
-    #import "DDLog.h"
+    #import <CocoaLumberjack/CocoaLumberjack.h>
 
 #ifndef IS_IPAD
 #define IS_IPAD   ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)

--- a/WordPress-iOS-SharedTests/AsyncTestHelper.m
+++ b/WordPress-iOS-SharedTests/AsyncTestHelper.m
@@ -2,4 +2,3 @@
 
 dispatch_semaphore_t ATHSemaphore;
 const NSTimeInterval AsyncTestCaseDefaultTimeout = 10;
-int ddLogLevel = LOG_LEVEL_INFO;


### PR DESCRIPTION
Closes #64 

This will help with updating to CocoaPods 0.36 and Xcode 6.3 on the subpods. We no longer have to define _ddLogLevel which is a HUGE help with libraries.