### PR TITLE
Fixes WPTableViewSectionFooterView height calculation

### DIFF
--- a/WordPress-iOS-Shared-Example/Podfile.lock
+++ b/WordPress-iOS-Shared-Example/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - AFNetworking (2.5.3):
-    - AFNetworking/NSURLConnection (= 2.5.3)
-    - AFNetworking/NSURLSession (= 2.5.3)
-    - AFNetworking/Reachability (= 2.5.3)
-    - AFNetworking/Security (= 2.5.3)
-    - AFNetworking/Serialization (= 2.5.3)
-    - AFNetworking/UIKit (= 2.5.3)
-  - AFNetworking/NSURLConnection (2.5.3):
+  - AFNetworking (2.5.4):
+    - AFNetworking/NSURLConnection (= 2.5.4)
+    - AFNetworking/NSURLSession (= 2.5.4)
+    - AFNetworking/Reachability (= 2.5.4)
+    - AFNetworking/Security (= 2.5.4)
+    - AFNetworking/Serialization (= 2.5.4)
+    - AFNetworking/UIKit (= 2.5.4)
+  - AFNetworking/NSURLConnection (2.5.4):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.3):
+  - AFNetworking/NSURLSession (2.5.4):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.3)
-  - AFNetworking/Security (2.5.3)
-  - AFNetworking/Serialization (2.5.3)
-  - AFNetworking/UIKit (2.5.3):
+  - AFNetworking/Reachability (2.5.4)
+  - AFNetworking/Security (2.5.4)
+  - AFNetworking/Serialization (2.5.4)
+  - AFNetworking/UIKit (2.5.4):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - CocoaLumberjack (2.0.0):
@@ -28,20 +28,20 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.0.0):
     - CocoaLumberjack/Default
-  - WordPress-iOS-Shared (0.3.2):
+  - WordPress-iOS-Shared (0.3.5):
     - AFNetworking (~> 2.5)
-    - CocoaLumberjack (~> 2.0)
+    - CocoaLumberjack (= 2.0.0)
 
 DEPENDENCIES:
   - WordPress-iOS-Shared (from `../`)
 
 EXTERNAL SOURCES:
   WordPress-iOS-Shared:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
+  AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
-  WordPress-iOS-Shared: 0164a2cd656003e0e69c468a11d0bb8a5da43ab0
+  WordPress-iOS-Shared: 155109cd666b8416ce0d2bdb2b8f6f6f6ec2ac50
 
 COCOAPODS: 0.37.2

--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.3.4"
+  s.version      = "0.3.5"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m
@@ -27,7 +27,7 @@ CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 24.0;
         _titleLabel.font = [WPStyleGuide subtitleFont];
         _titleLabel.textColor = [WPStyleGuide greyDarken10];
         _titleLabel.backgroundColor = [UIColor clearColor];
-        _titleLabel.shadowOffset = CGSizeMake(0.0, 0.0);
+        _titleLabel.shadowOffset = CGSizeZero;
         [self addSubview:_titleLabel];
 
         // fixed width should be enabled by default
@@ -55,7 +55,6 @@ CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 24.0;
     self.titleLabel.frame = CGRectIntegral(CGRectMake(padding, WPTableViewSectionFooterViewTopVerticalPadding, titleWidth, titleSize.height));
 }
 
-// fixedWidth is enabled by default
 + (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width
 {
     return [self heightForTitle:title andWidth:width fixedWidthEnabled:YES];
@@ -75,7 +74,7 @@ CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 24.0;
 
 + (CGSize)sizeForTitle:(NSString *)title andTitleWidth:(CGFloat)titleWidth
 {
-    return [title suggestedSizeWithFont:[WPStyleGuide tableviewSectionHeaderFont] width:titleWidth];
+    return [title suggestedSizeWithFont:[WPStyleGuide subtitleFont] width:titleWidth];
 }
 
 + (CGFloat)titleLabelWidthFromSectionWidth:(CGFloat)sectionWidth fixedWidthEnabled:(BOOL)fixedWidthEnabled


### PR DESCRIPTION
We were using a different font for the Height calculation. In this PR we're simply normalizing both fonts, and updating the Podspec as well.

Needs Review: @diegoreymendez (Thank you Diego!)
