### PR TITLE
WPTableViewSectionFooter: Adds Title Alignment Property

### DIFF
--- a/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.h
@@ -2,7 +2,8 @@
 
 @interface WPTableViewSectionFooterView : UITableViewHeaderFooterView
 
-@property (nonatomic, strong) NSString *title;
+@property (nonatomic, strong) NSString          *title;
+@property (nonatomic, assign) NSTextAlignment   titleAlignment;
 
 // By default, fixedWidth will be enabled, which means for iPads
 // the title label width will be <= WPTableViewFixedWidth. There

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m
@@ -43,6 +43,16 @@ CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 24.0;
     [self setNeedsLayout];
 }
 
+- (void)setTitleAlignment:(NSTextAlignment)textAlignment
+{
+    self.titleLabel.textAlignment = textAlignment;
+}
+
+- (NSTextAlignment)titleAlignment
+{
+    return self.titleLabel.textAlignment;
+}
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];


### PR DESCRIPTION
We'll expose the Title Alignment, which is required to wrap up [this WPiOS Issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/3998)

Needs Review: @diegoreymendez 
