### PR TITLE
Update Travis Xcode version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
+osx_image: xcode7.1
 language: objective-c
 xcode_workspace: WordPress-iOS-Shared.xcworkspace
 xcode_scheme: WordPress-iOS-Shared
-xcode_sdk: iphonesimulator8.1
+xcode_sdk: iphonesimulator


### PR DESCRIPTION
This seems to get us cocoapods 0.39 and fixes the build errors

Needs Review: @jleandroperez 