### PR TITLE
Deprecate WPTableViewSectionHeaderFooterView

### DIFF
--- a/WordPress-iOS-Shared/Core/WPStyleGuide.h
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.h
@@ -69,6 +69,8 @@
 + (void)configureTableViewActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewDestructiveActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewTextCell:(WPTextFieldTableViewCell *)cell;
++ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header;
++ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer;
 
 // Move to a feature category
 + (UIColor *)buttonActionColor;

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.h
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.h
@@ -69,8 +69,8 @@
 + (void)configureTableViewActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewDestructiveActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewTextCell:(WPTextFieldTableViewCell *)cell;
-+ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header;
-+ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer;
++ (void)configureTableViewSectionHeader:(UIView *)header;
++ (void)configureTableViewSectionFooter:(UIView *)footer;
 
 // Move to a feature category
 + (UIColor *)buttonActionColor;

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -415,12 +415,18 @@
 
 + (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header
 {
+    if (![header isKindOfClass:[UITableViewHeaderFooterView class]]) {
+        return;
+    }
     header.textLabel.font = [self tableviewSectionHeaderFont];
     header.textLabel.textColor = [self whisperGrey];
 }
 
 + (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer
 {
+    if (![footer isKindOfClass:[UITableViewHeaderFooterView class]]) {
+        return;
+    }
     footer.textLabel.font = [self subtitleFont];
     footer.textLabel.textColor = [self greyDarken10];
 }

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -413,6 +413,18 @@
     }
 }
 
++ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header
+{
+    header.textLabel.font = [self tableviewSectionHeaderFont];
+    header.textLabel.textColor = [self whisperGrey];
+}
+
++ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer
+{
+    footer.textLabel.font = [self subtitleFont];
+    footer.textLabel.textColor = [self greyDarken10];
+}
+
 // TODO: Move to fetaure category
 + (void)configureFollowButton:(UIButton *)followButton {
     followButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, WPTableViewSectionStyle)
  *          should be used app-wide.
  */
 
+__deprecated_msg("Use +[WPStyleGuide configureTableViewSectionHeader:] from the table view delegate instead")
 @interface WPTableViewSectionHeaderFooterView : UITableViewHeaderFooterView
 
 @property (nonatomic, assign, readonly) WPTableViewSectionStyle style;


### PR DESCRIPTION
WPTableViewSectionHeaderFooterView started its life as a way to customize the section headers to adapt to iOS 7 design changes, and has grown into a different beast today.

Of all the things it does, we just care about using a custom font and color, which can be achieved without custom classes, using the delegate method `tableView:willDisplayHeaderView:forSection:`.

I've marked WPTableViewSectionHeaderFooterView as deprecated and it should be removed in a next version once everything is migrated.

I've also added a couple new methods to call on `tableView:willDisplayHeaderView:forSection:` and `tableView:willDisplayFooterView:forSection:`.

For example usage see https://github.com/wordpress-mobile/WordPress-iOS/pull/4591