### PR TITLE
Revert "Deprecate WPTableViewSectionHeaderFooterView"

### DIFF
--- a/WordPress-iOS-Shared/Core/WPStyleGuide.h
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.h
@@ -69,8 +69,6 @@
 + (void)configureTableViewActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewDestructiveActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewTextCell:(WPTextFieldTableViewCell *)cell;
-+ (void)configureTableViewSectionHeader:(UIView *)header;
-+ (void)configureTableViewSectionFooter:(UIView *)footer;
 
 // Move to a feature category
 + (UIColor *)buttonActionColor;

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -413,24 +413,6 @@
     }
 }
 
-+ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header
-{
-    if (![header isKindOfClass:[UITableViewHeaderFooterView class]]) {
-        return;
-    }
-    header.textLabel.font = [self tableviewSectionHeaderFont];
-    header.textLabel.textColor = [self whisperGrey];
-}
-
-+ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer
-{
-    if (![footer isKindOfClass:[UITableViewHeaderFooterView class]]) {
-        return;
-    }
-    footer.textLabel.font = [self subtitleFont];
-    footer.textLabel.textColor = [self greyDarken10];
-}
-
 // TODO: Move to fetaure category
 + (void)configureFollowButton:(UIButton *)followButton {
     followButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
@@ -23,7 +23,6 @@ typedef NS_ENUM(NSInteger, WPTableViewSectionStyle)
  *          should be used app-wide.
  */
 
-__deprecated_msg("Use +[WPStyleGuide configureTableViewSectionHeader:] from the table view delegate instead")
 @interface WPTableViewSectionHeaderFooterView : UITableViewHeaderFooterView
 
 @property (nonatomic, assign, readonly) WPTableViewSectionStyle style;


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Shared-iOS#85

In https://github.com/wordpress-mobile/WordPress-iOS/pull/4591we decided not to go forward until we can get rid of `WPTableViewCell`