### PR TITLE
Add tint color to table view cell image views

### DIFF
--- a/WordPress-iOS-Shared-Example/Podfile.lock
+++ b/WordPress-iOS-Shared-Example/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - WordPress-iOS-Shared (0.5.2):
+  - WordPress-iOS-Shared (0.5.3):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.2.0)
 
@@ -37,11 +37,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WordPress-iOS-Shared:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  WordPress-iOS-Shared: af84c229bd1cb0206f6015fd8fec9e262a88c780
+  WordPress-iOS-Shared: 43f55f24f0685e431167084071b7914d7c7134a8
 
 COCOAPODS: 0.39.0

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -376,6 +376,8 @@
     
     cell.textLabel.textColor = [self darkGrey];
     cell.detailTextLabel.textColor = [self grey];
+    
+    cell.imageView.tintColor = [self greyLighten10];
 }
 
 + (void)configureTableViewSmallSubtitleCell:(UITableViewCell *)cell


### PR DESCRIPTION
Closes #88 

Adds a default 10% lightened grey to all image views in table view cells.

Needs Review: @jleandroperez 
