### PR TITLE
Add WordPressShared framework target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.1
+osx_image: xcode7.3
 language: objective-c
 script:
 - set -o pipefail && xcodebuild -workspace WordPress-iOS-Shared.xcworkspace -scheme WordPressShared -sdk iphonesimulator build test ONLY_ACTIVE_ARCH=NO | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 osx_image: xcode7.1
 language: objective-c
-xcode_workspace: WordPress-iOS-Shared.xcworkspace
-xcode_scheme: WordPressShared
-xcode_sdk: iphonesimulator
+script:
+- set -o pipefail && xcodebuild -workspace WordPress-iOS-Shared.xcworkspace -scheme WordPressShared -sdk iphonesimulator build test ONLY_ACTIVE_ARCH=NO | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 osx_image: xcode7.1
 language: objective-c
 xcode_workspace: WordPress-iOS-Shared.xcworkspace
-xcode_scheme: WordPress-iOS-Shared
+xcode_scheme: WordPressShared
 xcode_sdk: iphonesimulator

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '7.0'
+use_frameworks!
+platform :ios, '8.0'
 
 pod 'CocoaLumberjack', '~> 2.2.0'
 

--- a/WordPress-iOS-Shared-Example/Podfile
+++ b/WordPress-iOS-Shared-Example/Podfile
@@ -1,4 +1,5 @@
-platform :ios, '7.0'
+platform :ios, '8.0'
+use_frameworks!
 
 target "WordPress-iOS-Shared-Example" do
   pod "WordPress-iOS-Shared", :path => "../"

--- a/WordPress-iOS-Shared-Example/Podfile.lock
+++ b/WordPress-iOS-Shared-Example/Podfile.lock
@@ -15,10 +15,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WordPress-iOS-Shared:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  WordPress-iOS-Shared: e9e81a6a3cc3b45de93c8a565422c11395813c49
+  WordPress-iOS-Shared: 99fd974e8831cc02edb48429fa689155c85de79f
 
 COCOAPODS: 0.39.0

--- a/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example.xcodeproj/project.pbxproj
+++ b/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E3752D7BFA5FF869DAF7D6B /* Pods_WordPress_iOS_Shared_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 849A3B7F7FFC8895BF865DBE /* Pods_WordPress_iOS_Shared_Example.framework */; };
 		598E77111A8E4F2C0020DC05 /* DeviceTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 598E77101A8E4F2C0020DC05 /* DeviceTableViewController.m */; };
 		598E77141A8E535F0020DC05 /* DeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 598E77131A8E535F0020DC05 /* DeviceTest.m */; };
 		598E77171A8E53EE0020DC05 /* DeviceTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 598E77161A8E53EE0020DC05 /* DeviceTableViewCell.m */; };
@@ -21,19 +22,18 @@
 		85A420C51977993100F0F603 /* FontTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 85A420C41977993100F0F603 /* FontTableViewCell.m */; };
 		85D9A73D1977891600480221 /* FontsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D9A73C1977891600480221 /* FontsTableViewController.m */; };
 		85D9A7401977891F00480221 /* ColorsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D9A73F1977891F00480221 /* ColorsTableViewController.m */; };
-		EC81CE668DE94D458BA9910B /* libPods-WordPress-iOS-Shared-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37B298F8355D4CE69AA04521 /* libPods-WordPress-iOS-Shared-Example.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		2AE838413EB18EF1792640E7 /* Pods-WordPress-iOS-Shared-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress-iOS-Shared-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPress-iOS-Shared-Example/Pods-WordPress-iOS-Shared-Example.release.xcconfig"; sourceTree = "<group>"; };
 		2FEB7BA7F0B0C7DC85D5391A /* Pods-WordPress-iOS-Shared-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress-iOS-Shared-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPress-iOS-Shared-Example/Pods-WordPress-iOS-Shared-Example.debug.xcconfig"; sourceTree = "<group>"; };
-		37B298F8355D4CE69AA04521 /* libPods-WordPress-iOS-Shared-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WordPress-iOS-Shared-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		598E770F1A8E4F2C0020DC05 /* DeviceTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceTableViewController.h; sourceTree = "<group>"; };
 		598E77101A8E4F2C0020DC05 /* DeviceTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceTableViewController.m; sourceTree = "<group>"; };
 		598E77121A8E535F0020DC05 /* DeviceTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceTest.h; sourceTree = "<group>"; };
 		598E77131A8E535F0020DC05 /* DeviceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceTest.m; sourceTree = "<group>"; };
 		598E77151A8E53EE0020DC05 /* DeviceTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceTableViewCell.h; sourceTree = "<group>"; };
 		598E77161A8E53EE0020DC05 /* DeviceTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceTableViewCell.m; sourceTree = "<group>"; };
+		849A3B7F7FFC8895BF865DBE /* Pods_WordPress_iOS_Shared_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPress_iOS_Shared_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		852FBB45197755CC002C5249 /* WordPress-iOS-Shared-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WordPress-iOS-Shared-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		852FBB48197755CC002C5249 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		852FBB4A197755CC002C5249 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -63,7 +63,7 @@
 				852FBB4B197755CC002C5249 /* CoreGraphics.framework in Frameworks */,
 				852FBB4D197755CC002C5249 /* UIKit.framework in Frameworks */,
 				852FBB49197755CC002C5249 /* Foundation.framework in Frameworks */,
-				EC81CE668DE94D458BA9910B /* libPods-WordPress-iOS-Shared-Example.a in Frameworks */,
+				0E3752D7BFA5FF869DAF7D6B /* Pods_WordPress_iOS_Shared_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,7 +95,7 @@
 				852FBB4A197755CC002C5249 /* CoreGraphics.framework */,
 				852FBB4C197755CC002C5249 /* UIKit.framework */,
 				852FBB6A197755CC002C5249 /* XCTest.framework */,
-				37B298F8355D4CE69AA04521 /* libPods-WordPress-iOS-Shared-Example.a */,
+				849A3B7F7FFC8895BF865DBE /* Pods_WordPress_iOS_Shared_Example.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -374,6 +374,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example-Prefix.pch";
 				INFOPLIST_FILE = "WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -388,6 +389,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example-Prefix.pch";
 				INFOPLIST_FILE = "WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.license      = "GPLv2"
   s.author             = { "Automattic" => "mobile@automattic.com", "Aaron Douglas" => "astralbodies@gmail.com", "Sergio Estevao" => "sergioestevao@gmail.com" }
   s.social_media_url   = "http://twitter.com/WordPressiOS"
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "8.0"
   s.source       = { :git => "https://github.com/wordpress-mobile/WordPress-iOS-Shared.git", :tag => s.version.to_s }
   s.source_files = [ 'WordPress-iOS-Shared/Core', 'WordPress-iOS-Shared/Private' ]
   s.public_header_files = 'WordPress-iOS-Shared/Core/*.h'

--- a/WordPress-iOS-Shared.xcodeproj/project.pbxproj
+++ b/WordPress-iOS-Shared.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		931A0FFC192A9CDD00D3CC11 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 931A0FFB192A9CDD00D3CC11 /* XCTest.framework */; };
 		931A0FFD192A9CDD00D3CC11 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 931A0FED192A9CDD00D3CC11 /* Foundation.framework */; };
 		931A0FFF192A9CDD00D3CC11 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 931A0FFE192A9CDD00D3CC11 /* UIKit.framework */; };
-		931A1002192A9CDD00D3CC11 /* libWordPress-iOS-Shared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 931A0FEA192A9CDD00D3CC11 /* libWordPress-iOS-Shared.a */; };
 		931A1008192A9CDD00D3CC11 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 931A1006192A9CDD00D3CC11 /* InfoPlist.strings */; };
 		931A1016192A9D5200D3CC11 /* NSString+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1015192A9D5200D3CC11 /* NSString+Util.m */; };
 		931A1019192A9D6E00D3CC11 /* NSString+XMLExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1018192A9D6E00D3CC11 /* NSString+XMLExtensions.m */; };
@@ -58,17 +57,19 @@
 		E1016C351CBF764600CE57D8 /* WPFontManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F535F61961F7E6002D4320 /* WPFontManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1016C361CBF764600CE57D8 /* WPFontManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F535F71961F7E6002D4320 /* WPFontManager.m */; };
 		E1016C381CBF794F00CE57D8 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1016C371CBF794F00CE57D8 /* Pods.framework */; };
+		E1016C391CBF7C5A00CE57D8 /* WordPressShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1016BF91CBF760F00CE57D8 /* WordPressShared.framework */; };
+		E1016C3E1CBF7E5800CE57D8 /* UIColorHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1016C3D1CBF7E5800CE57D8 /* UIColorHelpersTests.swift */; };
 		FF8DDCE11B5E91050098826F /* WPTextFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF8DDCE01B5E91050098826F /* WPTextFieldTableViewCell.m */; };
 		FFBC2B371CBBE10300B0379E /* anim-reader.gif in Resources */ = {isa = PBXBuildFile; fileRef = FFBC2B361CBBE10300B0379E /* anim-reader.gif */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		931A1000192A9CDD00D3CC11 /* PBXContainerItemProxy */ = {
+		E1016C3A1CBF7C6000CE57D8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 931A0FE2192A9CDD00D3CC11 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 931A0FE9192A9CDD00D3CC11;
-			remoteInfo = "WordPress-iOS-Shared";
+			remoteGlobalIDString = E1016BF81CBF760F00CE57D8;
+			remoteInfo = WordPressShared;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -130,6 +131,8 @@
 		E1016BFB1CBF760F00CE57D8 /* WordPressShared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WordPressShared.h; sourceTree = "<group>"; };
 		E1016BFD1CBF760F00CE57D8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E1016C371CBF794F00CE57D8 /* Pods.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods.framework; path = "../../../Library/Developer/Xcode/DerivedData/WordPress-iOS-Shared-hfumuyfnkuhovufljfrgpelsvapk/Build/Products/Debug-iphonesimulator/Pods.framework"; sourceTree = "<group>"; };
+		E1016C3C1CBF7E5700CE57D8 /* WordPress-iOS-SharedTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPress-iOS-SharedTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		E1016C3D1CBF7E5800CE57D8 /* UIColorHelpersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorHelpersTests.swift; sourceTree = "<group>"; };
 		E95607083C359C14B48BA503 /* Pods-WordPress-iOS-SharedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress-iOS-SharedTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPress-iOS-SharedTests/Pods-WordPress-iOS-SharedTests.release.xcconfig"; sourceTree = "<group>"; };
 		FF14587C1CBE6D37004A5A0B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		FF14587D1CBE6D37004A5A0B /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
@@ -154,7 +157,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				931A1002192A9CDD00D3CC11 /* libWordPress-iOS-Shared.a in Frameworks */,
+				E1016C391CBF7C5A00CE57D8 /* WordPressShared.framework in Frameworks */,
 				931A0FFC192A9CDD00D3CC11 /* XCTest.framework in Frameworks */,
 				931A0FFF192A9CDD00D3CC11 /* UIKit.framework in Frameworks */,
 				931A0FFD192A9CDD00D3CC11 /* Foundation.framework in Frameworks */,
@@ -293,6 +296,8 @@
 			isa = PBXGroup;
 			children = (
 				931A1037192AA34300D3CC11 /* WPImageSourceTest.m */,
+				E1016C3D1CBF7E5800CE57D8 /* UIColorHelpersTests.swift */,
+				E1016C3C1CBF7E5700CE57D8 /* WordPress-iOS-SharedTests-Bridging-Header.h */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -406,7 +411,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				931A1001192A9CDD00D3CC11 /* PBXTargetDependency */,
+				E1016C3B1CBF7C6000CE57D8 /* PBXTargetDependency */,
 			);
 			name = "WordPress-iOS-SharedTests";
 			productName = "WordPress-iOS-SharedTests";
@@ -437,6 +442,7 @@
 		931A0FE2192A9CDD00D3CC11 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = WordPress.org;
 				TargetAttributes = {
@@ -589,6 +595,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				931A1038192AA34300D3CC11 /* WPImageSourceTest.m in Sources */,
+				E1016C3E1CBF7E5800CE57D8 /* UIColorHelpersTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -615,10 +622,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		931A1001192A9CDD00D3CC11 /* PBXTargetDependency */ = {
+		E1016C3B1CBF7C6000CE57D8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 931A0FE9192A9CDD00D3CC11 /* WordPress-iOS-Shared */;
-			targetProxy = 931A1000192A9CDD00D3CC11 /* PBXContainerItemProxy */;
+			target = E1016BF81CBF760F00CE57D8 /* WordPressShared */;
+			targetProxy = E1016C3A1CBF7C6000CE57D8 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -665,7 +672,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -696,7 +703,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -734,6 +741,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 897FA2B40A6E81DB4E7F0435 /* Pods-WordPress-iOS-SharedTests.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -746,7 +754,10 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "WordPress-iOS-SharedTests/WordPress-iOS-SharedTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WordPress-iOS-SharedTests/WordPress-iOS-SharedTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -755,6 +766,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E95607083C359C14B48BA503 /* Pods-WordPress-iOS-SharedTests.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -763,7 +775,9 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch";
 				INFOPLIST_FILE = "WordPress-iOS-SharedTests/WordPress-iOS-SharedTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WordPress-iOS-SharedTests/WordPress-iOS-SharedTests-Bridging-Header.h";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/WordPress-iOS-Shared.xcodeproj/project.pbxproj
+++ b/WordPress-iOS-Shared.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5491CC08CC7A4237B0CD8FA9 /* libPods-WordPress-iOS-SharedTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A7CDA9068CC847B2AD67DE41 /* libPods-WordPress-iOS-SharedTests.a */; };
 		598E770E1A8E3D1A0020DC05 /* WPDeviceIdentification.m in Sources */ = {isa = PBXBuildFile; fileRef = 598E770D1A8E3D1A0020DC05 /* WPDeviceIdentification.m */; };
+		6DD592FD91F85C0A450A7718 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF17CFFAE3A40C50CEE2D2F1 /* Pods.framework */; };
 		744DA846194F3A76002CD6E9 /* UIImage+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 744DA845194F3A76002CD6E9 /* UIImage+Util.m */; };
 		7462F3401961FAAB00CC8EED /* WPFontManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F535F71961F7E6002D4320 /* WPFontManager.m */; };
 		9309B52D192BEECC00B69F69 /* WordPressShared.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309B52C192BEECC00B69F69 /* WordPressShared.m */; };
@@ -29,7 +29,35 @@
 		931A1035192AA03600D3CC11 /* UIColor+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1034192AA03600D3CC11 /* UIColor+Helpers.m */; };
 		931A1038192AA34300D3CC11 /* WPImageSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1037192AA34300D3CC11 /* WPImageSourceTest.m */; };
 		931A103E192AA3DB00D3CC11 /* test-image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 931A103D192AA3DB00D3CC11 /* test-image.jpg */; };
-		F45AF04D6E344F4CBD2A4B65 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB8B405468864FD7A0D16B74 /* libPods.a */; };
+		D311ED4811F83546564A2672 /* Pods_WordPress_iOS_SharedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EF5AAE1978DEA22517D6992 /* Pods_WordPress_iOS_SharedTests.framework */; };
+		E1016BFC1CBF760F00CE57D8 /* WordPressShared.h in Headers */ = {isa = PBXBuildFile; fileRef = E1016BFB1CBF760F00CE57D8 /* WordPressShared.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C1D1CBF763D00CE57D8 /* UIColor+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1034192AA03600D3CC11 /* UIColor+Helpers.m */; };
+		E1016C1E1CBF763D00CE57D8 /* WPNoResultsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A101F192A9DD500D3CC11 /* WPNoResultsView.m */; };
+		E1016C1F1CBF763D00CE57D8 /* WPNUXUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1025192A9E0B00D3CC11 /* WPNUXUtility.m */; };
+		E1016C201CBF763D00CE57D8 /* WPStyleGuide.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1022192A9DFC00D3CC11 /* WPStyleGuide.m */; };
+		E1016C211CBF763D00CE57D8 /* WPTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1028192A9E2400D3CC11 /* WPTableViewCell.m */; };
+		E1016C221CBF763D00CE57D8 /* WPTableViewSectionHeaderFooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A102B192A9E3200D3CC11 /* WPTableViewSectionHeaderFooterView.m */; };
+		E1016C231CBF763D00CE57D8 /* WPTextFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF8DDCE01B5E91050098826F /* WPTextFieldTableViewCell.m */; };
+		E1016C241CBF764100CE57D8 /* UIColor+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A1033192AA03600D3CC11 /* UIColor+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C251CBF764100CE57D8 /* WPNoResultsView.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A101E192A9DD500D3CC11 /* WPNoResultsView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C261CBF764100CE57D8 /* WPNUXUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A1024192A9E0B00D3CC11 /* WPNUXUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C271CBF764100CE57D8 /* WPStyleGuide.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A1021192A9DFC00D3CC11 /* WPStyleGuide.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C281CBF764100CE57D8 /* WPTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A1027192A9E2400D3CC11 /* WPTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C291CBF764100CE57D8 /* WPTableViewSectionHeaderFooterView.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A102A192A9E3200D3CC11 /* WPTableViewSectionHeaderFooterView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C2A1CBF764100CE57D8 /* WPTextFieldTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A1030192A9F3500D3CC11 /* WPTextFieldTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C2B1CBF764600CE57D8 /* UIImage+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = 744DA844194F3A76002CD6E9 /* UIImage+Util.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C2C1CBF764600CE57D8 /* UIImage+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 744DA845194F3A76002CD6E9 /* UIImage+Util.m */; };
+		E1016C2D1CBF764600CE57D8 /* WPImageSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A101A192A9DA500D3CC11 /* WPImageSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C2E1CBF764600CE57D8 /* WPImageSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A101B192A9DA500D3CC11 /* WPImageSource.m */; };
+		E1016C2F1CBF764600CE57D8 /* NSString+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A1014192A9D5200D3CC11 /* NSString+Util.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C301CBF764600CE57D8 /* NSString+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1015192A9D5200D3CC11 /* NSString+Util.m */; };
+		E1016C311CBF764600CE57D8 /* NSString+XMLExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 931A1017192A9D6E00D3CC11 /* NSString+XMLExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C321CBF764600CE57D8 /* NSString+XMLExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 931A1018192A9D6E00D3CC11 /* NSString+XMLExtensions.m */; };
+		E1016C331CBF764600CE57D8 /* WPDeviceIdentification.h in Headers */ = {isa = PBXBuildFile; fileRef = 598E770C1A8E3D1A0020DC05 /* WPDeviceIdentification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C341CBF764600CE57D8 /* WPDeviceIdentification.m in Sources */ = {isa = PBXBuildFile; fileRef = 598E770D1A8E3D1A0020DC05 /* WPDeviceIdentification.m */; };
+		E1016C351CBF764600CE57D8 /* WPFontManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F535F61961F7E6002D4320 /* WPFontManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1016C361CBF764600CE57D8 /* WPFontManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F535F71961F7E6002D4320 /* WPFontManager.m */; };
+		E1016C381CBF794F00CE57D8 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1016C371CBF794F00CE57D8 /* Pods.framework */; };
 		FF8DDCE11B5E91050098826F /* WPTextFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF8DDCE01B5E91050098826F /* WPTextFieldTableViewCell.m */; };
 		FFBC2B371CBBE10300B0379E /* anim-reader.gif in Resources */ = {isa = PBXBuildFile; fileRef = FFBC2B361CBBE10300B0379E /* anim-reader.gif */; };
 /* End PBXBuildFile section */
@@ -58,6 +86,7 @@
 
 /* Begin PBXFileReference section */
 		1CCBEF3A622A4635247597B3 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		2EF5AAE1978DEA22517D6992 /* Pods_WordPress_iOS_SharedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPress_iOS_SharedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		598E770C1A8E3D1A0020DC05 /* WPDeviceIdentification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPDeviceIdentification.h; path = Core/WPDeviceIdentification.h; sourceTree = "<group>"; };
 		598E770D1A8E3D1A0020DC05 /* WPDeviceIdentification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPDeviceIdentification.m; path = Core/WPDeviceIdentification.m; sourceTree = "<group>"; };
 		744DA844194F3A76002CD6E9 /* UIImage+Util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+Util.h"; path = "Core/UIImage+Util.h"; sourceTree = "<group>"; };
@@ -97,13 +126,16 @@
 		931A1037192AA34300D3CC11 /* WPImageSourceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPImageSourceTest.m; sourceTree = "<group>"; };
 		931A103D192AA3DB00D3CC11 /* test-image.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "test-image.jpg"; sourceTree = "<group>"; };
 		98398B801DD76BC0326A4729 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		A7CDA9068CC847B2AD67DE41 /* libPods-WordPress-iOS-SharedTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WordPress-iOS-SharedTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		AB8B405468864FD7A0D16B74 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1016BF91CBF760F00CE57D8 /* WordPressShared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WordPressShared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1016BFB1CBF760F00CE57D8 /* WordPressShared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WordPressShared.h; sourceTree = "<group>"; };
+		E1016BFD1CBF760F00CE57D8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E1016C371CBF794F00CE57D8 /* Pods.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods.framework; path = "../../../Library/Developer/Xcode/DerivedData/WordPress-iOS-Shared-hfumuyfnkuhovufljfrgpelsvapk/Build/Products/Debug-iphonesimulator/Pods.framework"; sourceTree = "<group>"; };
 		E95607083C359C14B48BA503 /* Pods-WordPress-iOS-SharedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress-iOS-SharedTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPress-iOS-SharedTests/Pods-WordPress-iOS-SharedTests.release.xcconfig"; sourceTree = "<group>"; };
 		FF14587C1CBE6D37004A5A0B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		FF14587D1CBE6D37004A5A0B /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
 		FF14587E1CBE6D37004A5A0B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		FF1458801CBE6D59004A5A0B /* WordPress-iOS-Shared.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "WordPress-iOS-Shared.podspec"; sourceTree = "<group>"; };
+		FF17CFFAE3A40C50CEE2D2F1 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF8DDCE01B5E91050098826F /* WPTextFieldTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPTextFieldTableViewCell.m; path = Core/WPTextFieldTableViewCell.m; sourceTree = "<group>"; };
 		FFBC2B361CBBE10300B0379E /* anim-reader.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = "anim-reader.gif"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -114,7 +146,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				931A0FEE192A9CDD00D3CC11 /* Foundation.framework in Frameworks */,
-				F45AF04D6E344F4CBD2A4B65 /* libPods.a in Frameworks */,
+				6DD592FD91F85C0A450A7718 /* Pods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,7 +158,15 @@
 				931A0FFC192A9CDD00D3CC11 /* XCTest.framework in Frameworks */,
 				931A0FFF192A9CDD00D3CC11 /* UIKit.framework in Frameworks */,
 				931A0FFD192A9CDD00D3CC11 /* Foundation.framework in Frameworks */,
-				5491CC08CC7A4237B0CD8FA9 /* libPods-WordPress-iOS-SharedTests.a in Frameworks */,
+				D311ED4811F83546564A2672 /* Pods_WordPress_iOS_SharedTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E1016BF51CBF760F00CE57D8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1016C381CBF794F00CE57D8 /* Pods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,6 +179,7 @@
 				FF14587B1CBE6D24004A5A0B /* Podspec Metadata */,
 				931A0FEF192A9CDD00D3CC11 /* WordPress-iOS-Shared */,
 				931A1003192A9CDD00D3CC11 /* WordPress-iOS-SharedTests */,
+				E1016BFA1CBF760F00CE57D8 /* WordPressShared */,
 				931A0FEC192A9CDD00D3CC11 /* Frameworks */,
 				931A0FEB192A9CDD00D3CC11 /* Products */,
 				E17299F8EC7CFF36CD4A166A /* Pods */,
@@ -150,6 +191,7 @@
 			children = (
 				931A0FEA192A9CDD00D3CC11 /* libWordPress-iOS-Shared.a */,
 				931A0FFA192A9CDD00D3CC11 /* WordPress-iOS-SharedTests.xctest */,
+				E1016BF91CBF760F00CE57D8 /* WordPressShared.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -157,11 +199,12 @@
 		931A0FEC192A9CDD00D3CC11 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E1016C371CBF794F00CE57D8 /* Pods.framework */,
 				931A0FED192A9CDD00D3CC11 /* Foundation.framework */,
 				931A0FFB192A9CDD00D3CC11 /* XCTest.framework */,
 				931A0FFE192A9CDD00D3CC11 /* UIKit.framework */,
-				AB8B405468864FD7A0D16B74 /* libPods.a */,
-				A7CDA9068CC847B2AD67DE41 /* libPods-WordPress-iOS-SharedTests.a */,
+				FF17CFFAE3A40C50CEE2D2F1 /* Pods.framework */,
+				2EF5AAE1978DEA22517D6992 /* Pods_WordPress_iOS_SharedTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -263,6 +306,15 @@
 			name = "Test Data";
 			sourceTree = "<group>";
 		};
+		E1016BFA1CBF760F00CE57D8 /* WordPressShared */ = {
+			isa = PBXGroup;
+			children = (
+				E1016BFB1CBF760F00CE57D8 /* WordPressShared.h */,
+				E1016BFD1CBF760F00CE57D8 /* Info.plist */,
+			);
+			path = WordPressShared;
+			sourceTree = "<group>";
+		};
 		E154809F1A43035700FA4EDD /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -295,6 +347,30 @@
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		E1016BF61CBF760F00CE57D8 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1016C241CBF764100CE57D8 /* UIColor+Helpers.h in Headers */,
+				E1016C271CBF764100CE57D8 /* WPStyleGuide.h in Headers */,
+				E1016C2D1CBF764600CE57D8 /* WPImageSource.h in Headers */,
+				E1016C2F1CBF764600CE57D8 /* NSString+Util.h in Headers */,
+				E1016C251CBF764100CE57D8 /* WPNoResultsView.h in Headers */,
+				E1016C2A1CBF764100CE57D8 /* WPTextFieldTableViewCell.h in Headers */,
+				E1016C351CBF764600CE57D8 /* WPFontManager.h in Headers */,
+				E1016C311CBF764600CE57D8 /* NSString+XMLExtensions.h in Headers */,
+				E1016C331CBF764600CE57D8 /* WPDeviceIdentification.h in Headers */,
+				E1016C2B1CBF764600CE57D8 /* UIImage+Util.h in Headers */,
+				E1016C281CBF764100CE57D8 /* WPTableViewCell.h in Headers */,
+				E1016C261CBF764100CE57D8 /* WPNUXUtility.h in Headers */,
+				E1016C291CBF764100CE57D8 /* WPTableViewSectionHeaderFooterView.h in Headers */,
+				E1016BFC1CBF760F00CE57D8 /* WordPressShared.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		931A0FE9192A9CDD00D3CC11 /* WordPress-iOS-Shared */ = {
@@ -337,6 +413,24 @@
 			productReference = 931A0FFA192A9CDD00D3CC11 /* WordPress-iOS-SharedTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		E1016BF81CBF760F00CE57D8 /* WordPressShared */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E1016C001CBF760F00CE57D8 /* Build configuration list for PBXNativeTarget "WordPressShared" */;
+			buildPhases = (
+				E1016BF41CBF760F00CE57D8 /* Sources */,
+				E1016BF51CBF760F00CE57D8 /* Frameworks */,
+				E1016BF61CBF760F00CE57D8 /* Headers */,
+				E1016BF71CBF760F00CE57D8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WordPressShared;
+			productName = WordPressShared;
+			productReference = E1016BF91CBF760F00CE57D8 /* WordPressShared.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -345,6 +439,11 @@
 			attributes = {
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = WordPress.org;
+				TargetAttributes = {
+					E1016BF81CBF760F00CE57D8 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
 			};
 			buildConfigurationList = 931A0FE5192A9CDD00D3CC11 /* Build configuration list for PBXProject "WordPress-iOS-Shared" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -360,6 +459,7 @@
 			targets = (
 				931A0FE9192A9CDD00D3CC11 /* WordPress-iOS-Shared */,
 				931A0FF9192A9CDD00D3CC11 /* WordPress-iOS-SharedTests */,
+				E1016BF81CBF760F00CE57D8 /* WordPressShared */,
 			);
 		};
 /* End PBXProject section */
@@ -372,6 +472,13 @@
 				931A1008192A9CDD00D3CC11 /* InfoPlist.strings in Resources */,
 				FFBC2B371CBBE10300B0379E /* anim-reader.gif in Resources */,
 				931A103E192AA3DB00D3CC11 /* test-image.jpg in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E1016BF71CBF760F00CE57D8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -482,6 +589,26 @@
 			buildActionMask = 2147483647;
 			files = (
 				931A1038192AA34300D3CC11 /* WPImageSourceTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E1016BF41CBF760F00CE57D8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1016C1F1CBF763D00CE57D8 /* WPNUXUtility.m in Sources */,
+				E1016C321CBF764600CE57D8 /* NSString+XMLExtensions.m in Sources */,
+				E1016C211CBF763D00CE57D8 /* WPTableViewCell.m in Sources */,
+				E1016C1D1CBF763D00CE57D8 /* UIColor+Helpers.m in Sources */,
+				E1016C341CBF764600CE57D8 /* WPDeviceIdentification.m in Sources */,
+				E1016C2C1CBF764600CE57D8 /* UIImage+Util.m in Sources */,
+				E1016C231CBF763D00CE57D8 /* WPTextFieldTableViewCell.m in Sources */,
+				E1016C2E1CBF764600CE57D8 /* WPImageSource.m in Sources */,
+				E1016C221CBF763D00CE57D8 /* WPTableViewSectionHeaderFooterView.m in Sources */,
+				E1016C361CBF764600CE57D8 /* WPFontManager.m in Sources */,
+				E1016C301CBF764600CE57D8 /* NSString+Util.m in Sources */,
+				E1016C1E1CBF763D00CE57D8 /* WPNoResultsView.m in Sources */,
+				E1016C201CBF763D00CE57D8 /* WPStyleGuide.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -641,6 +768,70 @@
 			};
 			name = Release;
 		};
+		E1016BFE1CBF760F00CE57D8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CCBEF3A622A4635247597B3 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch";
+				INFOPLIST_FILE = WordPressShared/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		E1016BFF1CBF760F00CE57D8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CCBEF3A622A4635247597B3 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch";
+				INFOPLIST_FILE = WordPressShared/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -667,6 +858,15 @@
 			buildConfigurations = (
 				931A1011192A9CDD00D3CC11 /* Debug */,
 				931A1012192A9CDD00D3CC11 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E1016C001CBF760F00CE57D8 /* Build configuration list for PBXNativeTarget "WordPressShared" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1016BFE1CBF760F00CE57D8 /* Debug */,
+				E1016BFF1CBF760F00CE57D8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/WordPress-iOS-Shared.xcodeproj/project.pbxproj
+++ b/WordPress-iOS-Shared.xcodeproj/project.pbxproj
@@ -802,7 +802,7 @@
 				GCC_PREFIX_HEADER = "WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch";
 				INFOPLIST_FILE = WordPressShared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;
@@ -834,7 +834,7 @@
 				GCC_PREFIX_HEADER = "WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch";
 				INFOPLIST_FILE = WordPressShared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;

--- a/WordPress-iOS-Shared.xcodeproj/xcshareddata/xcschemes/WordPressShared.xcscheme
+++ b/WordPress-iOS-Shared.xcodeproj/xcshareddata/xcschemes/WordPressShared.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,14 +9,28 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "931A0FE9192A9CDD00D3CC11"
-               BuildableName = "libWordPress-iOS-Shared.a"
-               BlueprintName = "WordPress-iOS-Shared"
+               BlueprintIdentifier = "E1016BF81CBF760F00CE57D8"
+               BuildableName = "WordPressShared.framework"
+               BlueprintName = "WordPressShared"
+               ReferencedContainer = "container:WordPress-iOS-Shared.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "931A0FF9192A9CDD00D3CC11"
+               BuildableName = "WordPress-iOS-SharedTests.xctest"
+               BlueprintName = "WordPress-iOS-SharedTests"
                ReferencedContainer = "container:WordPress-iOS-Shared.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,13 +42,23 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "931A0FF9192A9CDD00D3CC11"
+               BuildableName = "WordPress-iOS-SharedTests.xctest"
+               BlueprintName = "WordPress-iOS-SharedTests"
+               ReferencedContainer = "container:WordPress-iOS-Shared.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "931A0FE9192A9CDD00D3CC11"
-            BuildableName = "libWordPress-iOS-Shared.a"
-            BlueprintName = "WordPress-iOS-Shared"
+            BlueprintIdentifier = "E1016BF81CBF760F00CE57D8"
+            BuildableName = "WordPressShared.framework"
+            BlueprintName = "WordPressShared"
             ReferencedContainer = "container:WordPress-iOS-Shared.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -54,9 +78,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "931A0FE9192A9CDD00D3CC11"
-            BuildableName = "libWordPress-iOS-Shared.a"
-            BlueprintName = "WordPress-iOS-Shared"
+            BlueprintIdentifier = "E1016BF81CBF760F00CE57D8"
+            BuildableName = "WordPressShared.framework"
+            BlueprintName = "WordPressShared"
             ReferencedContainer = "container:WordPress-iOS-Shared.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -69,6 +93,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1016BF81CBF760F00CE57D8"
+            BuildableName = "WordPressShared.framework"
+            BlueprintName = "WordPressShared"
+            ReferencedContainer = "container:WordPress-iOS-Shared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/WordPress-iOS-Shared/Core/WPDeviceIdentification.h
+++ b/WordPress-iOS-Shared/Core/WPDeviceIdentification.h
@@ -1,10 +1,32 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 /**
  *  @class      WPDeviceIdentification
  *  @brief      Methods for device and iOS identification should go here.
  */
 @interface WPDeviceIdentification : NSObject
+
+/**
+ *  @brief      Call this method to know if the current device is an iPhone.
+ *
+ *  @returns    YES if the device is an iPhone.  NO otherwise.
+ */
++ (BOOL)isiPhone;
+
+/**
+ *  @brief      Call this method to know if the current device is an iPad.
+ *
+ *  @returns    YES if the device is an iPad.  NO otherwise.
+ */
++ (BOOL)isiPad;
+
+/**
+ *  @brief      Call this method to know if the current device has a retina screen.
+ *
+ *  @returns    YES if the device has a retina screen.  NO otherwise.
+ */
++ (BOOL)isRetina;
 
 /**
  *  @brief      Call this method to know if the current device is an iPhone6.

--- a/WordPress-iOS-Shared/Core/WPDeviceIdentification.m
+++ b/WordPress-iOS-Shared/Core/WPDeviceIdentification.m
@@ -89,6 +89,19 @@ static NSString* const WPDeviceNameSimulator = @"Simulator";
 
 #pragma mark - Device identification
 
++ (BOOL)isiPhone {
+    return ![self isiPad];
+}
+
++ (BOOL)isiPad {
+    return [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad;
+}
+
++ (BOOL)isRetina {
+    return ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] && [[UIScreen mainScreen] scale] > 1);
+}
+
+
 + (BOOL)isiPhoneSix
 {
     NSString* deviceName = [self deviceName];
@@ -99,7 +112,7 @@ static NSString* const WPDeviceNameSimulator = @"Simulator";
         //  basically our best bet at identifying the device in lack of a better method.  This
         //  aproximation may need adjusting when new devices come out.
         //
-        result = (IS_IPHONE
+        result = ([self isiPhone]
                   && [[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]
                   && [[UIScreen mainScreen] respondsToSelector:@selector(nativeBounds)]
                   && [[UIScreen mainScreen] nativeScale] == 2
@@ -121,7 +134,7 @@ static NSString* const WPDeviceNameSimulator = @"Simulator";
         //  basically our best bet at identifying the device in lack of a better method.  This
         //  aproximation may need adjusting when new devices come out.
         //
-        result = (IS_IPHONE
+        result = ([self isiPhone]
                   && [[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]
                   && [[UIScreen mainScreen] respondsToSelector:@selector(nativeBounds)]
                   && [[UIScreen mainScreen] nativeScale] > 2.5

--- a/WordPress-iOS-Shared/Core/WPImageSource.h
+++ b/WordPress-iOS-Shared/Core/WPImageSource.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 /**
  WPImageSource Error Codes

--- a/WordPress-iOS-Shared/Core/WPNoResultsView.m
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.m
@@ -3,6 +3,7 @@
 #import "WPStyleGuide.h"
 #import "WPNUXUtility.h"
 #import "WPFontManager.h"
+#import "WPDeviceIdentification.h"
 
 @interface WPNoResultsView ()
 @property (nonatomic, strong) UILabel   *titleLabel;
@@ -226,7 +227,7 @@
     
     // Hide the accessory view in landscape orientation on iPhone to ensure entire view fits on screen
     UIDevice *device        = notification.object;
-    _accessoryView.hidden   = (UIDeviceOrientationIsLandscape(device.orientation) && IS_IPHONE);
+    _accessoryView.hidden   = (UIDeviceOrientationIsLandscape(device.orientation) && [WPDeviceIdentification isiPhone]);
     
     [self setNeedsLayout];
 }

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -2,6 +2,7 @@
 #import "WPTextFieldTableViewCell.h"
 #import "UIColor+Helpers.h"
 #import "WPFontManager.h"
+#import "WPDeviceIdentification.h"
 
 @implementation WPStyleGuide
 
@@ -278,14 +279,14 @@
     BOOL hasLighterKeyboard = [versionStr compare:@"7.1" options:NSNumericSearch] == NSOrderedAscending;
 
     if (hasLighterKeyboard) {
-        if (IS_IPAD) {
+        if ([WPDeviceIdentification isiPad]) {
             return [UIColor colorWithRed:207.0f/255.0f green:210.0f/255.0f blue:213.0f/255.0f alpha:1.0];
         } else {
             return [UIColor colorWithRed:220.0f/255.0f green:223.0f/255.0f blue:226.0f/255.0f alpha:1.0];
         }
     }
 
-    if (IS_IPAD) {
+    if ([WPDeviceIdentification isiPad]) {
         return [UIColor colorWithRed:217.0f/255.0f green:220.0f/255.0f blue:223.0f/255.0f alpha:1.0];
     } else {
         return [UIColor colorWithRed:204.0f/255.0f green:208.0f/255.0f blue:214.0f/255.0f alpha:1.0];

--- a/WordPress-iOS-Shared/Core/WPTableViewCell.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewCell.m
@@ -1,4 +1,5 @@
 #import "WPTableViewCell.h"
+#import "WPDeviceIdentification.h"
 
 CGFloat const WPTableViewFixedWidth = 600;
 
@@ -15,7 +16,7 @@ CGFloat const WPTableViewFixedWidth = 600;
 - (void)setFrame:(CGRect)frame {
     CGFloat width = self.superview.frame.size.width;
     // On iPad, add a margin around tables
-    if (IS_IPAD && width > WPTableViewFixedWidth) {
+    if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
         CGFloat x = (width - WPTableViewFixedWidth) / 2;
         // If origin.x is not equal to x we add the value.
         // This is a semi-fix / work around for an issue positioning cells on
@@ -35,7 +36,7 @@ CGFloat const WPTableViewFixedWidth = 600;
     
     // Need to set the origin again on iPad (for margins)
     CGFloat width = self.superview.frame.size.width;
-    if (IS_IPAD && width > WPTableViewFixedWidth) {
+    if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
         CGRect frame = self.frame;
         frame.origin.x = (width - WPTableViewFixedWidth) / 2;
         self.frame = frame;

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.m
@@ -1,8 +1,8 @@
 #import "WPTableViewSectionHeaderFooterView.h"
 #import "WPTableViewCell.h"
 #import "WPStyleGuide.h"
+#import "WPDeviceIdentification.h"
 #import "NSString+Util.h"
-
 
 
 @interface WPTableViewSectionHeaderFooterView ()
@@ -202,7 +202,7 @@
 
 + (CGFloat)fixedWidth
 {
-    return IS_IPAD ? WPTableViewFixedWidth : 0.0;
+    return [WPDeviceIdentification isiPad] ? WPTableViewFixedWidth : 0.0;
 }
 
 

--- a/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.m
+++ b/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.m
@@ -1,4 +1,5 @@
 #import "WPTextFieldTableViewCell.h"
+#import "WPDeviceIdentification.h"
 
 CGFloat const AccessoryPadding = 15.0f;
 CGFloat const iPadLeftMargin = 60.0f;
@@ -49,7 +50,7 @@ CGFloat const iPhoneRightMargin = 50.0f;
     if (!self.accessoryView && self.accessoryType != UITableViewCellAccessoryNone) {
         rightMargin = AccessoryPadding;
     }
-    if (IS_IPAD) {
+    if ([WPDeviceIdentification isiPad]) {
         leftMargin  = iPadLeftMargin;
         rightMargin += iPadRightMargin;
     } else {

--- a/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
+++ b/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
@@ -11,15 +11,4 @@
 #import <CocoaLumberjack/CocoaLumberjack.h>
 static const DDLogLevel WordPressSharedLogLevel = DDLogLevelWarning;
 
-#ifndef IS_IPAD
-#define IS_IPAD   ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
-#endif
-#ifndef IS_IPHONE
-#define IS_IPHONE   (!IS_IPAD)
-#endif
-#ifndef IS_RETINA
-#define IS_RETINA ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] && [[UIScreen mainScreen] scale] == 2)
-#endif
-
-
 #endif

--- a/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
+++ b/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
@@ -5,7 +5,6 @@
 //
 
 #ifdef __OBJC__
-    #import <UIKit/UIKit.h>
 
 #define LOG_LEVEL_DEF WordPressSharedLogLevel
 #import <CocoaLumberjack/CocoaLumberjack.h>

--- a/WordPress-iOS-SharedTests/UIColorHelpersTests.swift
+++ b/WordPress-iOS-SharedTests/UIColorHelpersTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import WordPressShared
+
+class UIColorHelpersTests: XCTestCase {
+
+    func testHexString() {
+        XCTAssertEqual(UIColor.redColor().hexString().lowercaseString, "ff0000")
+
+        // hexString only works for RGB colors
+        XCTAssertEqual(UIColor.blackColor().hexString(), nil)
+        XCTAssertEqual(UIColor(white: 1, alpha: 1).hexString(), nil)
+    }
+
+}

--- a/WordPress-iOS-SharedTests/WordPress-iOS-SharedTests-Bridging-Header.h
+++ b/WordPress-iOS-SharedTests/WordPress-iOS-SharedTests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/WordPressShared/Info.plist
+++ b/WordPressShared/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/WordPressShared/WordPressShared.h
+++ b/WordPressShared/WordPressShared.h
@@ -1,0 +1,23 @@
+#import <UIKit/UIKit.h>
+
+//! Project version number for WordPressShared.
+FOUNDATION_EXPORT double WordPressSharedVersionNumber;
+
+//! Project version string for WordPressShared.
+FOUNDATION_EXPORT const unsigned char WordPressSharedVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <WordPressShared/PublicHeader.h>
+
+#import <WordPressShared/NSString+Util.h>
+#import <WordPressShared/NSString+XMLExtensions.h>
+#import <WordPressShared/UIColor+Helpers.h>
+#import <WordPressShared/UIImage+Util.h>
+#import <WordPressShared/WPDeviceIdentification.h>
+#import <WordPressShared/WPFontManager.h>
+#import <WordPressShared/WPImageSource.h>
+#import <WordPressShared/WPNUXUtility.h>
+#import <WordPressShared/WPNoResultsView.h>
+#import <WordPressShared/WPStyleGuide.h>
+#import <WordPressShared/WPTableViewCell.h>
+#import <WordPressShared/WPTableViewSectionHeaderFooterView.h>
+#import <WordPressShared/WPTextFieldTableViewCell.h>


### PR DESCRIPTION
So far the project was building a static library. There are plenty of reasons to switch to frameworks but what triggered this was trying to add Swift code and Swift unit tests.

This PR:

- Adds a new `WordPressShared` framework target/scheme
- Bumps the iOS deployment target to 8.0, since it's the minimum that supports frameworks
- Switch the unit tests to use the framework instead of the static library
- Adds a small unit test in Swift to verify that it's working
- Removed `IS_IPAD` and other macros from the PCH file and converted them to regular methods in `WPDeviceIdentification`
- Switch travis to build the new scheme with xcodebuild, as that's what we're using everywhere else.

Needs Review: @SergioEstevao 