### PR TITLE
WPTableViewSectionHeaderFooterView: Added attributed title.

### DIFF
--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, WPTableViewSectionStyle)
 
 @property (nonatomic, assign, readonly) WPTableViewSectionStyle style;
 @property (nonatomic, strong) NSString *title;
+@property (nonatomic, strong) NSAttributedString *attributedTitle;
 @property (nonatomic, strong) UIColor *titleColor;
 @property (nonatomic, strong) UIFont *titleFont;
 @property (nonatomic, assign) NSTextAlignment titleAlignment;

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.m
@@ -98,6 +98,38 @@
     [self setNeedsLayout];
 }
 
+- (NSAttributedString *)attributedTitle
+{
+    return self.titleLabel.attributedText;
+}
+
+- (void)setAttributedTitle:(NSAttributedString *)attributedTitle
+{
+    if (self.uppercase) {
+        NSString *title = [[attributedTitle string] uppercaseStringWithLocale:[NSLocale currentLocale]];
+        
+        // If we're uppercasing the title then we'll need to copy any existing attributes...
+        NSMutableArray *attributes = [NSMutableArray new];
+        [attributedTitle enumerateAttributesInRange:NSMakeRange(0, [attributedTitle length])
+                                            options:0
+                                         usingBlock:^(NSDictionary *attr, NSRange range, BOOL *stop) {
+                                             [attributes addObject:@{ @"attr": attr, @"range": [NSValue valueWithRange:range] }];
+                                         }];
+        
+        NSMutableAttributedString *uppercaseTitle = [[NSMutableAttributedString alloc] initWithString:title];
+        
+        // And then apply them to a new uppercased string
+        for (NSDictionary *attribute in attributes) {
+            [uppercaseTitle setAttributes:attribute[@"attr"] range:[attribute[@"range"] rangeValue]];
+        }
+        
+        attributedTitle = uppercaseTitle;
+    }
+    
+    self.titleLabel.attributedText = attributedTitle;
+    [self setNeedsLayout];
+}
+
 - (UIColor *)titleColor
 {
     return self.titleLabel.textColor;


### PR DESCRIPTION
This PR adds an `attributedTitle` property to `WPTableViewSectionHeaderFooterView`, so that the text can have extra styles applied to it. 

This will initially be used to a create tappable-looking footer in the Plans section of WPiOS:

<img width="373" alt="screen shot 2016-04-13 at 21 47 04" src="https://cloud.githubusercontent.com/assets/4780/14508864/746d5604-01c1-11e6-8431-5cb64cfa8939.png">

To test:
* Check out the `feature/plans-tos-link` branch of WPiOS
* Map all references to `WordPress-iOS-Shared` in the `Podfile` to use this branch: `pod 'WordPress-iOS-Shared', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git', :branch => 'feature/attributed-header-footer-view'`
* Build and run WPiOS, navigate into a .com site, choose Plans, and view the footer at the bottom of the list.

Needs review: @jleandroperez 

Thanks!