### PR TITLE
Improved the code to properly hide the accessoryView in WPNoResultsView.

### DIFF
--- a/WordPress-iOS-Shared-Example/Podfile.lock
+++ b/WordPress-iOS-Shared-Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - WordPress-iOS-Shared (0.5.5):
+  - WordPress-iOS-Shared (0.5.6):
     - CocoaLumberjack (~> 2.2.0)
 
 DEPENDENCIES:
@@ -15,10 +15,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WordPress-iOS-Shared:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  WordPress-iOS-Shared: 99fd974e8831cc02edb48429fa689155c85de79f
+  WordPress-iOS-Shared: ce4b6e02763532e1737bf2bc7deed78d64ba4934
 
 COCOAPODS: 0.39.0

--- a/WordPress-iOS-Shared/Core/WPNoResultsView.m
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.m
@@ -29,6 +29,7 @@
 }
 
 - (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     self.delegate = nil;
 }
 
@@ -58,6 +59,10 @@
         [self addSubview:_titleLabel];
         [self addSubview:_messageLabel];
         [self addSubview:_button];
+        
+        // Listen for orientation changes
+        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+        [nc addObserver:self selector:@selector(orientationDidChange:) name:UIDeviceOrientationDidChangeNotification object:nil];
     }
     
     return self;
@@ -225,6 +230,12 @@
     frame.origin.x = x;
     frame.origin.y = y;
     self.frame = frame;
+}
+
+#pragma mark - Notification Hanlders
+
+- (void)orientationDidChange:(NSNotification *)notification {
+    [self setNeedsLayout];
 }
 
 - (void)buttonAction:(id)sender

--- a/WordPress-iOS-Shared/Core/WPNoResultsView.m
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.m
@@ -29,7 +29,6 @@
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     self.delegate = nil;
 }
 
@@ -59,10 +58,6 @@
         [self addSubview:_titleLabel];
         [self addSubview:_messageLabel];
         [self addSubview:_button];
-        
-        // Listen for orientation changes
-        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-        [nc addObserver:self selector:@selector(orientationDidChange:) name:UIDeviceOrientationDidChangeNotification object:nil];
     }
     
     return self;
@@ -75,6 +70,8 @@
 - (void)layoutSubviews {
     
     CGFloat width = 250.0f;
+    
+    [self hideAccessoryViewIfNecessary];
     
     // Layout views
     _accessoryView.frame = CGRectMake((width - CGRectGetWidth(_accessoryView.frame)) / 2, 0, CGRectGetWidth(_accessoryView.frame), CGRectGetHeight(_accessoryView.frame));
@@ -109,6 +106,16 @@
     if (self.superview) {
         [self centerInSuperview];
     }
+}
+
+#pragma mark - Accessory View
+
+/// Hide the accessory view in landscape orientation on iPhone to ensure entire view fits on screen
+///
+- (void)hideAccessoryViewIfNecessary
+{
+    UIDevice *device = [UIDevice currentDevice];
+    self.accessoryView.hidden = (UIDeviceOrientationIsLandscape(device.orientation) && [WPDeviceIdentification isiPhone]);
 }
 
 #pragma mark Helper Methods
@@ -218,18 +225,6 @@
     frame.origin.x = x;
     frame.origin.y = y;
     self.frame = frame;
-}
-
-
-#pragma mark - Notification Hanlders
-
-- (void)orientationDidChange:(NSNotification *)notification {
-    
-    // Hide the accessory view in landscape orientation on iPhone to ensure entire view fits on screen
-    UIDevice *device        = notification.object;
-    _accessoryView.hidden   = (UIDeviceOrientationIsLandscape(device.orientation) && [WPDeviceIdentification isiPhone]);
-    
-    [self setNeedsLayout];
 }
 
 - (void)buttonAction:(id)sender


### PR DESCRIPTION
### Description:

Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/5293), which is caused by the code not enforcing some GUI layout rules in the appropriate spots.

If the fix is accepted a follow-up PR will boost the pod version and properly include it in WPiOS.

### Testing:

1. Checkout WPiOS branch `issue/5293-no-results-accessory-view-problems`.
2. Reinstall the pods
3. Launch the app.
4. Go to the list of posts or pages for any of your blogs.
5. Make sure you select a filter with no results.
6. In portrait mode, the ink well image should be visible at all times.
7. In landscape mode, the ink well image should not be visible ever.  Do a pull-to-refresh on the list and make sure it stays that way.

Please review @aerych 

/cc @astralbodies 