### PR TITLE
UIColor hexString now works with grayscale colors.

### DIFF
--- a/WordPress-iOS-Shared/Core/UIColor+Helpers.m
+++ b/WordPress-iOS-Shared/Core/UIColor+Helpers.m
@@ -50,24 +50,34 @@
 - (NSString *)hexString
 {
     // Taken from http://stackoverflow.com/questions/8689424/uicolor-to-hexadecimal-web-color
-    
+
     NSString *webColor = nil;
-    
-    // This method only works for RGB colors
-    if (CGColorGetNumberOfComponents(self.CGColor) == 4)
+
+    size_t componentCount = CGColorGetNumberOfComponents(self.CGColor);
+
+    // RGB colors
+    if (componentCount == 4)
     {
         // Get the red, green and blue components
         const CGFloat *components = CGColorGetComponents(self.CGColor);
-        
+
         // These components range from 0.0 till 1.0 and need to be converted to 0 till 255
         CGFloat red = roundf(components[0] * 255.0);
         CGFloat green = roundf(components[1] * 255.0);
         CGFloat blue = roundf(components[2] * 255.0);
-        
+
         // Convert with %02x (use 02 to always get two chars)
         webColor = [NSString stringWithFormat:@"%02lx%02lx%02lx", (long)red, (long)green, (long)blue];
+    } else if (componentCount == 2) {   // Greyscale colors
+        // Get the white and alpha components
+        const CGFloat *components = CGColorGetComponents(self.CGColor);
+
+        // Same as above, but only using a single component
+        CGFloat white = roundf(components[0] * 255.0);
+
+        webColor = [NSString stringWithFormat:@"%02lx%02lx%02lx", (long)white, (long)white, (long)white];
     }
-    
+
     return webColor;
 }
 

--- a/WordPress-iOS-Shared/Core/UIColor+Helpers.m
+++ b/WordPress-iOS-Shared/Core/UIColor+Helpers.m
@@ -55,7 +55,7 @@
 
     size_t componentCount = CGColorGetNumberOfComponents(self.CGColor);
 
-    // RGB colors
+    // RGBA colors
     if (componentCount == 4)
     {
         // Get the red, green and blue components

--- a/WordPress-iOS-SharedTests/UIColorHelpersTests.swift
+++ b/WordPress-iOS-SharedTests/UIColorHelpersTests.swift
@@ -6,9 +6,9 @@ class UIColorHelpersTests: XCTestCase {
     func testHexString() {
         XCTAssertEqual(UIColor.redColor().hexString().lowercaseString, "ff0000")
 
-        // hexString only works for RGB colors
-        XCTAssertEqual(UIColor.blackColor().hexString(), nil)
-        XCTAssertEqual(UIColor(white: 1, alpha: 1).hexString(), nil)
+        // hexString works for RGB and grayscale colors
+        XCTAssertEqual(UIColor.blackColor().hexString().lowercaseString, "000000")
+        XCTAssertEqual(UIColor(white: 1, alpha: 1).hexString().lowercaseString, "ffffff")
     }
 
 }


### PR DESCRIPTION
I've updated `hexString` to support colors with only two components. This is needed for a new helper I'm adding to WPiOS which allows easier styling of attributed strings via HTML (requiring CSS / hex colors). Without this fix, `hexString` won't work with e.g. `UIColor.whiteColor()`.

To test: 

* Verify that the `UIColorHelpersTests` pass (and make sense!).
* Check the code :)

Needs review: @diegoreymendez  
Thanks!