### PR TITLE
Deprecate WPTableViewsectionHeaderFooterview

### DIFF
--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.5.9"
+  s.version      = "0.6.0"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.h
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.h
@@ -26,6 +26,7 @@
 + (UIFont *)tableviewTextFont;
 + (UIFont *)tableviewSubtitleFont;
 + (UIFont *)tableviewSectionHeaderFont;
++ (UIFont *)tableviewSectionFooterFont;
 
 // Color
 + (UIColor *)wordPressBlue;
@@ -69,6 +70,8 @@
 + (void)configureTableViewActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewDestructiveActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewTextCell:(WPTextFieldTableViewCell *)cell;
++ (void)configureTableViewSectionHeader:(UIView *)header;
++ (void)configureTableViewSectionFooter:(UIView *)footer;
 
 // Move to a feature category
 + (UIColor *)buttonActionColor;

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -141,6 +141,11 @@
     return [WPFontManager systemRegularFontOfSize:13.0];
 }
 
++ (UIFont *)tableviewSectionFooterFont
+{
+	return [WPFontManager systemRegularFontOfSize:13.0];
+}
+
 
 #pragma mark - Colors
 // https://wordpress.com/design-handbook/colors/
@@ -414,6 +419,24 @@
         cell.textField.textColor = [self grey];
         cell.textField.textAlignment = NSTextAlignmentRight;
     }
+}
+
++ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header
+{
+	if (![header isKindOfClass:[UITableViewHeaderFooterView class]]) {
+		return;
+	}
+	header.textLabel.font = [self tableviewSectionHeaderFont];
+	header.textLabel.textColor = [self whisperGrey];
+}
+
++ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer
+{
+	if (![footer isKindOfClass:[UITableViewHeaderFooterView class]]) {
+		return;
+	}
+	footer.textLabel.font = [self tableviewSectionFooterFont];
+	footer.textLabel.textColor = [self greyDarken10];
 }
 
 // TODO: Move to fetaure category

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, WPTableViewSectionStyle)
  *          should be used app-wide.
  */
 
+__deprecated_msg("Use +[WPStyleGuide configureTableViewSectionHeader:] from the table view delegate instead")
 @interface WPTableViewSectionHeaderFooterView : UITableViewHeaderFooterView
 
 @property (nonatomic, assign, readonly) WPTableViewSectionStyle style;


### PR DESCRIPTION
Deprecating `WPTableViewsectionHeaderFooterview` and adding new `WPStyleGuide` configuration methods for styling the usage of default `UITableViewHeaderFooterView` instances.

This brings the benefit of consistency with margins, fonts, and readability in our tableViews.

This is also a required precursor to the forthcoming merge of [WordPress-Shared-iOS/tree/feature/readability](https://github.com/wordpress-mobile/WordPress-Shared-iOS/tree/feature/readability).

Needs Review: @frosty 