### PR TITLE
Readability, by the death of WPTableViewCell

### DIFF
--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.6.1"
+  s.version      = "0.6.0"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.6.0"
+  s.version      = "0.6.1"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.5.9"
+  s.version      = "0.6.0"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.h
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.h
@@ -26,6 +26,7 @@
 + (UIFont *)tableviewTextFont;
 + (UIFont *)tableviewSubtitleFont;
 + (UIFont *)tableviewSectionHeaderFont;
++ (UIFont *)tableviewSectionFooterFont;
 
 // Color
 + (UIColor *)wordPressBlue;
@@ -69,6 +70,8 @@
 + (void)configureTableViewActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewDestructiveActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewTextCell:(WPTextFieldTableViewCell *)cell;
++ (void)configureTableViewSectionHeader:(UIView *)header;
++ (void)configureTableViewSectionFooter:(UIView *)footer;
 
 // Move to a feature category
 + (UIColor *)buttonActionColor;

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -141,6 +141,11 @@
     return [WPFontManager systemRegularFontOfSize:13.0];
 }
 
++ (UIFont *)tableviewSectionFooterFont
+{
+	return [WPFontManager systemRegularFontOfSize:13.0];
+}
+
 
 #pragma mark - Colors
 // https://wordpress.com/design-handbook/colors/
@@ -414,6 +419,24 @@
         cell.textField.textColor = [self grey];
         cell.textField.textAlignment = NSTextAlignmentRight;
     }
+}
+
++ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header
+{
+	if (![header isKindOfClass:[UITableViewHeaderFooterView class]]) {
+		return;
+	}
+	header.textLabel.font = [self tableviewSectionHeaderFont];
+	header.textLabel.textColor = [self whisperGrey];
+}
+
++ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer
+{
+	if (![footer isKindOfClass:[UITableViewHeaderFooterView class]]) {
+		return;
+	}
+	footer.textLabel.font = [self tableviewSectionFooterFont];
+	footer.textLabel.textColor = [self greyDarken10];
 }
 
 // TODO: Move to fetaure category

--- a/WordPress-iOS-Shared/Core/WPTableViewCell.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewCell.h
@@ -4,4 +4,10 @@ extern CGFloat const WPTableViewFixedWidth;
 
 @interface WPTableViewCell : UITableViewCell
 
+/**
+ Temporary flag for enabling the margins hack on cells, while views adopt readable margins.
+ Note: Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL forceCustomCellMargins;
+
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewCell.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewCell.m
@@ -5,42 +5,45 @@ CGFloat const WPTableViewFixedWidth = 600;
 
 @implementation WPTableViewCell
 
-- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
-    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
-    if (self) {
-        [self setClipsToBounds:YES];
-    }
-    return self;
+- (void)setForceCustomCellMargins:(BOOL)forceCustomCellMargins
+{
+	if (_forceCustomCellMargins != forceCustomCellMargins) {
+		_forceCustomCellMargins = forceCustomCellMargins;
+		[self setClipsToBounds:forceCustomCellMargins];
+	}
 }
 
 - (void)setFrame:(CGRect)frame {
-    CGFloat width = self.superview.frame.size.width;
-    // On iPad, add a margin around tables
-    if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
-        CGFloat x = (width - WPTableViewFixedWidth) / 2;
-        // If origin.x is not equal to x we add the value.
-        // This is a semi-fix / work around for an issue positioning cells on
-        // iOS 8 when editing a table view and the delete button is visible.
-        if (x != frame.origin.x) {
-            frame.origin.x += x;
-        } else {
-            frame.origin.x = x;
-        }
-        frame.size.width = WPTableViewFixedWidth;
-    }
-    [super setFrame:frame];
+	if (self.forceCustomCellMargins) {
+		CGFloat width = self.superview.frame.size.width;
+		// On iPad, add a margin around tables
+		if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
+			CGFloat x = (width - WPTableViewFixedWidth) / 2;
+			// If origin.x is not equal to x we add the value.
+			// This is a semi-fix / work around for an issue positioning cells on
+			// iOS 8 when editing a table view and the delete button is visible.
+			if (x != frame.origin.x) {
+				frame.origin.x += x;
+			} else {
+				frame.origin.x = x;
+			}
+			frame.size.width = WPTableViewFixedWidth;
+		}
+	}
+	[super setFrame:frame];
 }
 
 - (void)layoutSubviews {
-    [super layoutSubviews];
-    
-    // Need to set the origin again on iPad (for margins)
-    CGFloat width = self.superview.frame.size.width;
-    if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
-        CGRect frame = self.frame;
-        frame.origin.x = (width - WPTableViewFixedWidth) / 2;
-        self.frame = frame;
-    }
+	[super layoutSubviews];
+	if (self.forceCustomCellMargins) {
+		// Need to set the origin again on iPad (for margins)
+		CGFloat width = self.superview.frame.size.width;
+		if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
+			CGRect frame = self.frame;
+			frame.origin.x = (width - WPTableViewFixedWidth) / 2;
+			self.frame = frame;
+		}
+	}
 }
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, WPTableViewSectionStyle)
  *          should be used app-wide.
  */
 
+__deprecated_msg("Use +[WPStyleGuide configureTableViewSectionHeader:] from the table view delegate instead")
 @interface WPTableViewSectionHeaderFooterView : UITableViewHeaderFooterView
 
 @property (nonatomic, assign, readonly) WPTableViewSectionStyle style;

--- a/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.h
+++ b/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.h
@@ -13,9 +13,8 @@
 
 @interface WPTextFieldTableViewCell : WPTableViewCell
 
-@property (nonatomic, strong) UITextField *textField;
+@property (nonatomic, strong, readonly) UITextField *textField;
 @property (nonatomic, assign) BOOL shouldDismissOnReturn;
 @property (nonatomic, weak) id<WPTextFieldTableViewCellDelegate> delegate;
-@property (nonatomic, assign) CGFloat minimumLabelWidth;
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.m
+++ b/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.m
@@ -1,11 +1,11 @@
 #import "WPTextFieldTableViewCell.h"
 #import "WPDeviceIdentification.h"
 
-CGFloat const AccessoryPadding = 15.0f;
-CGFloat const iPadLeftMargin = 60.0f;
-CGFloat const iPadRightMargin = 100.0f;
-CGFloat const iPhoneLeftMargin = 30.0f;
-CGFloat const iPhoneRightMargin = 50.0f;
+CGFloat const TextFieldPadding = 15.0f;
+
+@interface WPCellTextField : UITextField
+@property (nonatomic, assign) UIEdgeInsets textMargins;
+@end
 
 @interface WPTextFieldTableViewCell () <UITextFieldDelegate>
 
@@ -16,52 +16,54 @@ CGFloat const iPhoneRightMargin = 50.0f;
 - (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
-        _textField = [[UITextField alloc] initWithFrame:self.bounds];
-        _textField.adjustsFontSizeToFitWidth = YES;
-        _textField.textColor = [UIColor blackColor];
-        _textField.backgroundColor = [UIColor clearColor];
-        _textField.autocorrectionType = UITextAutocorrectionTypeNo;
-        _textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-        _textField.textAlignment = NSTextAlignmentLeft;
-        _textField.clearButtonMode = UITextFieldViewModeNever;
-        _textField.enabled = YES;
-        _textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
-        _textField.delegate = self;
-        
-        _minimumLabelWidth = 90;
-        
+
         self.selectionStyle = UITableViewCellSelectionStyleNone;
         self.accessoryType = UITableViewCellAccessoryNone;
-        
-        [self.contentView addSubview:self.textField];
+
+		[self setupTextField];
     }
     
     return self;
 }
 
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    
-    CGSize labelSize = [self.textLabel.text sizeWithAttributes:@{NSFontAttributeName:[UIFont boldSystemFontOfSize:17]}];
-    labelSize.width = ceil(labelSize.width/5) * 5; // Round to upper 5
-    labelSize.width = MAX(self.minimumLabelWidth, labelSize.width); // Impose alignment for shorter labels
-    CGFloat leftMargin = 0;
-    CGFloat rightMargin = self.accessoryView.frame.size.width;
-    if (!self.accessoryView && self.accessoryType != UITableViewCellAccessoryNone) {
-        rightMargin = AccessoryPadding;
-    }
-    if ([WPDeviceIdentification isiPad]) {
-        leftMargin  = iPadLeftMargin;
-        rightMargin += iPadRightMargin;
-    } else {
-        leftMargin  = iPhoneLeftMargin;
-        rightMargin += iPhoneRightMargin;
-    }
-    CGRect frame = CGRectMake(labelSize.width + leftMargin,
-                       self.textLabel.frame.origin.y,
-                       self.frame.size.width - labelSize.width - rightMargin,
-                       self.textField.frame.size.height);
-    self.textField.frame = frame;
+- (void)setupTextField
+{
+	// Use a custom textField, see below for implementation of WPCellTextField.
+	WPCellTextField *textField = [[WPCellTextField alloc] init];
+	textField.translatesAutoresizingMaskIntoConstraints = NO;
+	textField.adjustsFontSizeToFitWidth = YES;
+	textField.textColor = [UIColor blackColor];
+	textField.backgroundColor = [UIColor clearColor];
+	textField.autocorrectionType = UITextAutocorrectionTypeNo;
+	textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+	textField.textAlignment = NSTextAlignmentLeft;
+	textField.clearButtonMode = UITextFieldViewModeNever;
+	textField.enabled = YES;
+	textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
+	textField.delegate = self;
+
+	[self.contentView addSubview:textField];
+	UILayoutGuide *layoutGuide = self.contentView.readableContentGuide;
+	[NSLayoutConstraint activateConstraints:@[
+											  [textField.leadingAnchor constraintEqualToAnchor:layoutGuide.leadingAnchor],
+											  [textField.trailingAnchor constraintEqualToAnchor:layoutGuide.trailingAnchor],
+											  [textField.topAnchor constraintEqualToAnchor:self.contentView.topAnchor],
+											  [textField.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor],
+											  [textField.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor]
+											  ]];
+	_textField = textField;
+}
+
+- (void)layoutSubviews
+{
+	[super layoutSubviews];
+
+
+	UIEdgeInsets textMargins = UIEdgeInsetsZero;
+	CGSize labelSize = [self.textLabel.text sizeWithAttributes:@{NSFontAttributeName:self.textLabel.font}];
+	textMargins.left = ceilf(labelSize.width) + TextFieldPadding;
+	WPCellTextField *textField = (WPCellTextField *)self.textField;
+	textField.textMargins = textMargins;
 }
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -97,6 +99,46 @@ CGFloat const iPhoneRightMargin = 50.0f;
     } else {
         self.textField.returnKeyType = UIReturnKeyNext;
     }
+}
+
+@end
+
+@implementation WPCellTextField
+
+/*
+ * The textField's leading edge needs to follow the trailing edge of the textLabel
+ * but the cell's textLabel layout runs the full width of the cell's contentView...
+ * So instead we apply given margins to the textField's textRect and editingRect to
+ * inset the text along the given margin, which currently is the textLabel's text width.
+ * Brent C. Jul/13/2016
+ */
+
+- (void)setTextMargins:(UIEdgeInsets)textMargins
+{
+	_textMargins = textMargins;
+	[self setNeedsDisplay];
+}
+
+- (CGRect)textRectWithMargins:(CGRect)rect
+{
+	UIEdgeInsets margins = self.textMargins;
+	rect.origin.x += margins.left;
+	rect.origin.y += margins.top;
+	rect.size.width -= margins.left + margins.right;
+	rect.size.height -= margins.top + margins.bottom;
+	return rect;
+}
+
+- (CGRect)textRectForBounds:(CGRect)bounds
+{
+	CGRect rect = [super textRectForBounds:bounds];
+	return [self textRectWithMargins:rect];
+}
+
+- (CGRect)editingRectForBounds:(CGRect)bounds
+{
+	CGRect rect = [super editingRectForBounds:bounds];
+	return [self textRectWithMargins:rect];
 }
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.m
+++ b/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.m
@@ -49,7 +49,6 @@ CGFloat const TextFieldPadding = 15.0f;
 											  [textField.trailingAnchor constraintEqualToAnchor:layoutGuide.trailingAnchor],
 											  [textField.topAnchor constraintEqualToAnchor:self.contentView.topAnchor],
 											  [textField.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor],
-											  [textField.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor]
 											  ]];
 	_textField = textField;
 }


### PR DESCRIPTION
This PR adds a toggle for disabling the layout margin hacks in `WPTableViewCell`.

We're adding a toggle here for now as to smooth the transition of WPiOS views not yet capable of coping with the loss of our long-maligned margin hacks.

In the very near future we'll remove this toggle and hack altogether when it is no longer needed.

This PR also cleans up and refactors `WPCellTextField` to follow the readable content guide.

Needs review: @frosty 