### PR TITLE
Readability, sans WPTableViewCell and WPTableViewSectionHeaderFooterView

### DIFF
--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.5.9"
+  s.version      = "0.6.0"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.h
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.h
@@ -26,6 +26,7 @@
 + (UIFont *)tableviewTextFont;
 + (UIFont *)tableviewSubtitleFont;
 + (UIFont *)tableviewSectionHeaderFont;
++ (UIFont *)tableviewSectionFooterFont;
 
 // Color
 + (UIColor *)wordPressBlue;
@@ -69,6 +70,8 @@
 + (void)configureTableViewActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewDestructiveActionCell:(UITableViewCell *)cell;
 + (void)configureTableViewTextCell:(WPTextFieldTableViewCell *)cell;
++ (void)configureTableViewSectionHeader:(UIView *)header;
++ (void)configureTableViewSectionFooter:(UIView *)footer;
 
 // Move to a feature category
 + (UIColor *)buttonActionColor;

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -141,6 +141,11 @@
     return [WPFontManager systemRegularFontOfSize:13.0];
 }
 
++ (UIFont *)tableviewSectionFooterFont
+{
+	return [WPFontManager systemRegularFontOfSize:13.0];
+}
+
 
 #pragma mark - Colors
 // https://wordpress.com/design-handbook/colors/
@@ -414,6 +419,24 @@
         cell.textField.textColor = [self grey];
         cell.textField.textAlignment = NSTextAlignmentRight;
     }
+}
+
++ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header
+{
+	if (![header isKindOfClass:[UITableViewHeaderFooterView class]]) {
+		return;
+	}
+	header.textLabel.font = [self tableviewSectionHeaderFont];
+	header.textLabel.textColor = [self whisperGrey];
+}
+
++ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer
+{
+	if (![footer isKindOfClass:[UITableViewHeaderFooterView class]]) {
+		return;
+	}
+	footer.textLabel.font = [self tableviewSectionFooterFont];
+	footer.textLabel.textColor = [self greyDarken10];
 }
 
 // TODO: Move to fetaure category

--- a/WordPress-iOS-Shared/Core/WPTableViewCell.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewCell.h
@@ -4,4 +4,10 @@ extern CGFloat const WPTableViewFixedWidth;
 
 @interface WPTableViewCell : UITableViewCell
 
+/**
+ Temporary flag for enabling the margins hack on cells, while views adopt readable margins.
+ Note: Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL forceCustomCellMargins;
+
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewCell.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewCell.m
@@ -5,42 +5,45 @@ CGFloat const WPTableViewFixedWidth = 600;
 
 @implementation WPTableViewCell
 
-- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
-    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
-    if (self) {
-        [self setClipsToBounds:YES];
-    }
-    return self;
+- (void)setForceCustomCellMargins:(BOOL)forceCustomCellMargins
+{
+	if (_forceCustomCellMargins != forceCustomCellMargins) {
+		_forceCustomCellMargins = forceCustomCellMargins;
+		[self setClipsToBounds:forceCustomCellMargins];
+	}
 }
 
 - (void)setFrame:(CGRect)frame {
-    CGFloat width = self.superview.frame.size.width;
-    // On iPad, add a margin around tables
-    if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
-        CGFloat x = (width - WPTableViewFixedWidth) / 2;
-        // If origin.x is not equal to x we add the value.
-        // This is a semi-fix / work around for an issue positioning cells on
-        // iOS 8 when editing a table view and the delete button is visible.
-        if (x != frame.origin.x) {
-            frame.origin.x += x;
-        } else {
-            frame.origin.x = x;
-        }
-        frame.size.width = WPTableViewFixedWidth;
-    }
-    [super setFrame:frame];
+	if (self.forceCustomCellMargins) {
+		CGFloat width = self.superview.frame.size.width;
+		// On iPad, add a margin around tables
+		if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
+			CGFloat x = (width - WPTableViewFixedWidth) / 2;
+			// If origin.x is not equal to x we add the value.
+			// This is a semi-fix / work around for an issue positioning cells on
+			// iOS 8 when editing a table view and the delete button is visible.
+			if (x != frame.origin.x) {
+				frame.origin.x += x;
+			} else {
+				frame.origin.x = x;
+			}
+			frame.size.width = WPTableViewFixedWidth;
+		}
+	}
+	[super setFrame:frame];
 }
 
 - (void)layoutSubviews {
-    [super layoutSubviews];
-    
-    // Need to set the origin again on iPad (for margins)
-    CGFloat width = self.superview.frame.size.width;
-    if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
-        CGRect frame = self.frame;
-        frame.origin.x = (width - WPTableViewFixedWidth) / 2;
-        self.frame = frame;
-    }
+	[super layoutSubviews];
+	if (self.forceCustomCellMargins) {
+		// Need to set the origin again on iPad (for margins)
+		CGFloat width = self.superview.frame.size.width;
+		if ([WPDeviceIdentification isiPad] && width > WPTableViewFixedWidth) {
+			CGRect frame = self.frame;
+			frame.origin.x = (width - WPTableViewFixedWidth) / 2;
+			self.frame = frame;
+		}
+	}
 }
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderFooterView.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, WPTableViewSectionStyle)
  *          should be used app-wide.
  */
 
+__deprecated_msg("Use +[WPStyleGuide configureTableViewSectionHeader:] from the table view delegate instead")
 @interface WPTableViewSectionHeaderFooterView : UITableViewHeaderFooterView
 
 @property (nonatomic, assign, readonly) WPTableViewSectionStyle style;

--- a/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.h
+++ b/WordPress-iOS-Shared/Core/WPTextFieldTableViewCell.h
@@ -13,9 +13,8 @@
 
 @interface WPTextFieldTableViewCell : WPTableViewCell
 
-@property (nonatomic, strong) UITextField *textField;
+@property (nonatomic, strong, readonly) UITextField *textField;
 @property (nonatomic, assign) BOOL shouldDismissOnReturn;
 @property (nonatomic, weak) id<WPTextFieldTableViewCellDelegate> delegate;
-@property (nonatomic, assign) CGFloat minimumLabelWidth;
 
 @end


### PR DESCRIPTION
Combined https://github.com/wordpress-mobile/WordPress-Shared-iOS/pull/103 and https://github.com/wordpress-mobile/WordPress-Shared-iOS/pull/104

This PR adds a toggle for disabling the layout margin hacks in `WPTableViewCell`.

We're adding a toggle here for now as to smooth the transition of WPiOS views not yet capable of coping with the loss of our long-maligned margin hacks.

In the very near future we'll remove this toggle and hack altogether when it is no longer needed.

This PR also cleans up and refactors `WPCellTextField` to follow the readable content guide.

This PR is also deprecating `WPTableViewsectionHeaderFooterview` and adding new `WPStyleGuide` configuration methods for styling the usage of default `UITableViewHeaderFooterView` instances. This brings the benefit of consistency with margins, fonts, and readability in our tableViews.

Note: This should be merged and released before merging https://github.com/wordpress-mobile/WordPress-iOS/pull/5756 and https://github.com/wordpress-mobile/WordPress-iOS/pull/5764 which rely on this version.

Needs review: @frosty one more look please? 👀