### PR TITLE
WPNoResultsView now takes into account table header and footer views

### DIFF
--- a/WordPress-iOS-Shared/Core/WPNoResultsView.m
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.m
@@ -203,29 +203,40 @@
 }
 
 - (void)centerInSuperview {
-    
+
     if (!self.superview) {
         return;
     }
-    
+
     // Center in superview
     CGRect frame = [self superview].frame;
-    
+
     // account for content insets of superview if it is a scrollview
     if ([self.superview.class isSubclassOfClass:[UIScrollView class]]) {
         UIScrollView *scrollView = (UIScrollView *)self.superview;
-        
+
         CGFloat verticalOffset = scrollView.contentInset.top + scrollView.contentInset.bottom;
         CGFloat horizontalOffset =  scrollView.contentInset.left + scrollView.contentInset.right;
-        
+
+        if ([self.superview isKindOfClass:[UITableView class]]) {
+            UITableView *tableView = (UITableView *)self.superview;
+            CGFloat headerHeight = tableView.tableHeaderView.hidden ? 0 : tableView.tableHeaderView.bounds.size.height;
+            CGFloat footerHeight = tableView.tableFooterView.hidden ? 0 : tableView.tableFooterView.bounds.size.height;
+
+            verticalOffset += (headerHeight + footerHeight);
+
+            // Offset the frame's top if we have a header
+            frame.origin.y = headerHeight;
+        }
+
         // Sanity check to make sure the offsets are not set to large values
         frame.size.height = frame.size.height - verticalOffset > 0 ? frame.size.height - verticalOffset : frame.size.height;
         frame.size.width = frame.size.width - horizontalOffset > 0 ? frame.size.width - horizontalOffset : frame.size.width;
     }
-    
+
     CGFloat x = (CGRectGetWidth(frame) - CGRectGetWidth(self.frame))/2.0;
-    CGFloat y = ((CGRectGetHeight(frame)) - CGRectGetHeight(self.frame))/2.0;
-    
+    CGFloat y = (CGRectGetHeight(frame) / 2.0) - (CGRectGetHeight(self.frame) / 2.0) + frame.origin.y;
+
     frame = self.frame;
     frame.origin.x = x;
     frame.origin.y = y;

--- a/WordPress-iOS-Shared/Core/WPNoResultsView.m
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.m
@@ -220,8 +220,8 @@
 
         if ([self.superview isKindOfClass:[UITableView class]]) {
             UITableView *tableView = (UITableView *)self.superview;
-            CGFloat headerHeight = tableView.tableHeaderView.hidden ? 0 : tableView.tableHeaderView.bounds.size.height;
-            CGFloat footerHeight = tableView.tableFooterView.hidden ? 0 : tableView.tableFooterView.bounds.size.height;
+            CGFloat headerHeight = (tableView.tableHeaderView == nil || tableView.tableHeaderView.hidden) ? 0 : tableView.tableHeaderView.bounds.size.height;
+            CGFloat footerHeight = (tableView.tableFooterView == nil || tableView.tableFooterView.hidden) ? 0 : tableView.tableFooterView.bounds.size.height;
 
             verticalOffset += (headerHeight + footerHeight);
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5765 by adjusting the vertical position of `WPNoResultsView` to account for table header and footer views.

To test:

* Using this branch, ensure that the no results view appears vertically centered in all locations that call `centerInSuperview` in WPiOS.
* Ensure that the no results view isn't partially hidden on the posts list on an iPhone 4s.

Needs review: @aerych 