### PR TITLE
Expose WPNoResultsView button publicly

### DIFF
--- a/WordPress-iOS-Shared-Example/Podfile.lock
+++ b/WordPress-iOS-Shared-Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - WordPress-iOS-Shared (0.6.2):
+  - WordPress-iOS-Shared (0.6.3):
     - CocoaLumberjack (~> 2.2.0)
 
 DEPENDENCIES:
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  WordPress-iOS-Shared: 96b5695837cfa907d17122b250e83e05b59b6039
+  WordPress-iOS-Shared: 2496fba282efcdcb8182f8f282ca0eb56dc4eb32
 
 PODFILE CHECKSUM: 8196d0bef0b4757ec5d593c176fec8a0ebac8e4f
 

--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.6.2"
+  s.version      = "0.6.3"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared/Core/WPNoResultsView.h
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.h
@@ -13,6 +13,7 @@
 @property (nonatomic, strong) NSString                      *messageText;
 @property (nonatomic, strong) NSString                      *buttonTitle;
 @property (nonatomic, strong) UIView                        *accessoryView;
+@property (nonatomic, strong) UIButton                      *button;
 @property (nonatomic,   weak) id<WPNoResultsViewDelegate>   delegate;
 
 + (instancetype)noResultsViewWithTitle:(NSString *)titleText message:(NSString *)messageText accessoryView:(UIView *)accessoryView buttonTitle:(NSString *)buttonTitle;

--- a/WordPress-iOS-Shared/Core/WPNoResultsView.m
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.m
@@ -8,7 +8,6 @@
 @interface WPNoResultsView ()
 @property (nonatomic, strong) UILabel   *titleLabel;
 @property (nonatomic, strong) UILabel   *messageLabel;
-@property (nonatomic, strong) UIButton  *button;
 @end
 
 @implementation WPNoResultsView


### PR DESCRIPTION
This PR moves the declaration for `WPNoResultsView`'s button from a private class extension to the class's header, as per the suggestion here: https://github.com/wordpress-mobile/WordPress-iOS/pull/5802#discussion_r81882366

I'm adding functionality to WPiOS which displays a popover from the button, so its frame needs to be known to provide a `sourceRect` for the popover.

Needs review: @kurzee 