### PR TITLE
Add dynamic type sizes to WPStyleGuide

### DIFF
--- a/WordPress-iOS-Shared/Core/WPStyleGuide.h
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.h
@@ -4,12 +4,6 @@
 @interface WPStyleGuide : NSObject
 
 // Fonts
-+ (UIFont *)largePostTitleFont;
-+ (NSDictionary *)largePostTitleAttributes;
-+ (UIFont *)postTitleFont;
-+ (UIFont *)postTitleFontBold;
-+ (NSDictionary *)postTitleAttributes;
-+ (NSDictionary *)postTitleAttributesBold;
 + (UIFont *)subtitleFont;
 + (NSDictionary *)subtitleAttributes;
 + (UIFont *)subtitleFontItalic;
@@ -21,7 +15,6 @@
 + (NSDictionary *)labelAttributes;
 + (UIFont *)regularTextFont;
 + (UIFont *)regularTextFontSemiBold;
-+ (UIFont *)regularTextFontBold;
 + (NSDictionary *)regularTextAttributes;
 + (UIFont *)tableviewTextFont;
 + (UIFont *)tableviewSubtitleFont;

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -8,44 +8,6 @@
 
 #pragma mark - Fonts and Text
 
-+ (UIFont *)largePostTitleFont
-{
-    return [UIFont preferredFontForTextStyle:UIFontTextStyleTitle1];
-}
-
-+ (NSDictionary *)largePostTitleAttributes
-{
-    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    paragraphStyle.minimumLineHeight = 35;
-    paragraphStyle.maximumLineHeight = 35;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [self largePostTitleFont]};
-}
-
-+ (UIFont *)postTitleFont
-{
-    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-}
-
-+ (UIFont *)postTitleFontBold
-{
-    return [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
-}
-
-+ (NSDictionary *)postTitleAttributes
-{
-    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    paragraphStyle.minimumLineHeight = 19;
-    paragraphStyle.maximumLineHeight = 19;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [self postTitleFont]};
-}
-
-+ (NSDictionary *)postTitleAttributesBold {
-    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    paragraphStyle.minimumLineHeight = 19;
-    paragraphStyle.maximumLineHeight = 19;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [self postTitleFontBold]};
-}
-
 + (UIFont *)subtitleFont
 {
     return [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
@@ -111,11 +73,6 @@
 + (UIFont *)regularTextFontSemiBold
 {
     return [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
-}
-
-+ (UIFont *)regularTextFontBold
-{
-    return [UIFont systemFontOfSize:[[self regularTextFont] pointSize] weight:UIFontWeightBold];
 }
 
 + (NSDictionary *)regularTextAttributes

--- a/WordPress-iOS-Shared/Core/WPStyleGuide.m
+++ b/WordPress-iOS-Shared/Core/WPStyleGuide.m
@@ -10,7 +10,7 @@
 
 + (UIFont *)largePostTitleFont
 {
-    return [WPFontManager systemLightFontOfSize:32.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleTitle1];
 }
 
 + (NSDictionary *)largePostTitleAttributes
@@ -23,12 +23,12 @@
 
 + (UIFont *)postTitleFont
 {
-    return [WPFontManager systemRegularFontOfSize:16.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 + (UIFont *)postTitleFontBold
 {
-    return [WPFontManager systemBoldFontOfSize:16.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
 }
 
 + (NSDictionary *)postTitleAttributes
@@ -48,7 +48,7 @@
 
 + (UIFont *)subtitleFont
 {
-    return [WPFontManager systemRegularFontOfSize:12.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
 }
 
 + (NSDictionary *)subtitleAttributes
@@ -61,7 +61,7 @@
 
 + (UIFont *)subtitleFontItalic
 {
-    return [WPFontManager systemItalicFontOfSize:12.0];
+    return [UIFont italicSystemFontOfSize:[[self subtitleFont] pointSize]];
 }
 
 + (NSDictionary *)subtitleItalicAttributes
@@ -74,7 +74,7 @@
 
 + (UIFont *)subtitleFontBold
 {
-    return [WPFontManager systemBoldFontOfSize:12.0];
+    return [UIFont systemFontOfSize:[[self subtitleFont] pointSize] weight:UIFontWeightBold];
 }
 
 + (NSDictionary *)subtitleAttributesBold
@@ -87,12 +87,12 @@
 
 + (UIFont *)labelFont
 {
-    return [WPFontManager systemBoldFontOfSize:10.0];
+    return [UIFont systemFontOfSize:[[self labelFontNormal] pointSize] weight:UIFontWeightBold];
 }
 
 + (UIFont *)labelFontNormal
 {
-    return [WPFontManager systemRegularFontOfSize:10.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
 }
 
 + (NSDictionary *)labelAttributes
@@ -105,17 +105,17 @@
 
 + (UIFont *)regularTextFont
 {
-    return [WPFontManager systemRegularFontOfSize:16.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 + (UIFont *)regularTextFontSemiBold
 {
-    return [WPFontManager systemSemiBoldFontOfSize:16.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
 }
 
 + (UIFont *)regularTextFontBold
 {
-    return [WPFontManager systemBoldFontOfSize:16.0];
+    return [UIFont systemFontOfSize:[[self regularTextFont] pointSize] weight:UIFontWeightBold];
 }
 
 + (NSDictionary *)regularTextAttributes
@@ -128,22 +128,22 @@
 
 + (UIFont *)tableviewTextFont
 {
-    return [WPFontManager systemRegularFontOfSize:17.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 + (UIFont *)tableviewSubtitleFont
 {
-    return [WPFontManager systemRegularFontOfSize:17.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 + (UIFont *)tableviewSectionHeaderFont
 {
-    return [WPFontManager systemRegularFontOfSize:13.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
 }
 
 + (UIFont *)tableviewSectionFooterFont
 {
-	return [WPFontManager systemRegularFontOfSize:13.0];
+	return [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
 }
 
 


### PR DESCRIPTION
Adding dynamic type sizes to `WPStyleGuide` is a first step toward full dynamic type support.

It breaks, like, very few things :P 

Needs review: @aerych 