### PR TITLE
Redirect issues to main WP-iOS repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ WordPress-iOS-Shared
 ======================
 
 This project contains shared items between the WordPress-iOS application and other components.  This is a work in progress.
+
+
+### Issues
+Please log any issues in the main [WordPress-iOS repository](https://github.com/wordpress-mobile/WordPress-iOS/issues).


### PR DESCRIPTION
This repo only gets a few issues, and they seem to be mostly ignored. I think we can track them better within the main WP-iOS repo.

Any thoughts @koke?