### PR TITLE
Improve no results view

### DIFF
--- a/WordPress-iOS-Shared.podspec
+++ b/WordPress-iOS-Shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPress-iOS-Shared"
-  s.version      = "0.8.0"
+  s.version      = "0.8.1"
   s.summary      = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description  = <<-DESC

--- a/WordPress-iOS-Shared/Core/WPNoResultsView.m
+++ b/WordPress-iOS-Shared/Core/WPNoResultsView.m
@@ -48,10 +48,10 @@
         
         // Button
         _button                     = [UIButton buttonWithType:UIButtonTypeCustom];
-        _button.titleLabel.font     = [WPStyleGuide regularTextFont];
+        _button.titleLabel.font     = [WPStyleGuide subtitleFontBold];
         _button.hidden              = YES;
         [_button addTarget:self action:@selector(buttonAction:) forControlEvents:UIControlEventTouchUpInside];
-        [_button setTitleColor:[WPStyleGuide allTAllShadeGrey] forState:UIControlStateNormal];
+        [_button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
         [_button setBackgroundImage:[self newButtonBackgroundImage] forState:UIControlStateNormal];
         
         // Insert Subviews
@@ -73,7 +73,7 @@
 
 - (void)layoutSubviews {
     
-    CGFloat width = 250.0f;
+    CGFloat width = 280.0f;
     
     [self hideAccessoryViewIfNecessary];
     
@@ -131,8 +131,9 @@
     UIGraphicsBeginImageContextWithOptions(fillRect.size, NO, [[UIScreen mainScreen] scale]);
     CGContextRef context    = UIGraphicsGetCurrentContext();
     
-    CGContextSetStrokeColorWithColor(context, [WPStyleGuide allTAllShadeGrey].CGColor);
-    CGContextAddPath(context, [UIBezierPath bezierPathWithRoundedRect:CGRectInset(fillRect, 1, 1) cornerRadius:2.0].CGPath);
+    CGContextSetStrokeColorWithColor(context, [WPStyleGuide wordPressBlue].CGColor);
+    CGContextAddPath(context, [UIBezierPath bezierPathWithRoundedRect:CGRectInset(fillRect, 1, 1)
+                                                         cornerRadius:2.0].CGPath);
     CGContextStrokePath(context);
     
     UIImage *mainImage = UIGraphicsGetImageFromCurrentImageContext();
@@ -219,8 +220,12 @@
 
         if ([self.superview isKindOfClass:[UITableView class]]) {
             UITableView *tableView = (UITableView *)self.superview;
-            CGFloat headerHeight = (tableView.tableHeaderView == nil || tableView.tableHeaderView.hidden) ? 0 : tableView.tableHeaderView.bounds.size.height;
-            CGFloat footerHeight = (tableView.tableFooterView == nil || tableView.tableFooterView.hidden) ? 0 : tableView.tableFooterView.bounds.size.height;
+            CGFloat headerHeight = (tableView.tableHeaderView == nil
+                                    || tableView.tableHeaderView.hidden
+                                    || tableView.tableHeaderView.alpha == 0.0) ? 0 : tableView.tableHeaderView.bounds.size.height;
+            CGFloat footerHeight = (tableView.tableFooterView == nil
+                                    || tableView.tableFooterView.hidden
+                                    || tableView.tableFooterView.alpha == 0.0) ? 0 : tableView.tableFooterView.bounds.size.height;
 
             verticalOffset += (headerHeight + footerHeight);
 


### PR DESCRIPTION
Updates WPNoResultsView so it looks a little bit more appealing:
1. Update button border and text color to WordPress blue
2. Update button title font to a bolder one
3. Increase view width
4. Take into account header and footer views with alpha == 0 when calculating the view position

 Before        | After           
------------ | -------------
![simulator screen shot mar 22 2017 09 59 44](https://cloud.githubusercontent.com/assets/5558824/24214824/75030a8e-0f15-11e7-9317-d4626a50c42a.png) | ![simulator screen shot mar 22 2017 15 43 45](https://cloud.githubusercontent.com/assets/5558824/24215082/615ed6ba-0f16-11e7-963a-693ac4ec59a7.png)
